### PR TITLE
Do not hardcode marathon to localhost

### DIFF
--- a/mesosstatecache.lua
+++ b/mesosstatecache.lua
@@ -60,7 +60,7 @@ end
 local function fetch_and_cache_state_marathon()
     -- Access Marathon through localhost.
     ngx.log(ngx.NOTICE, "Cache Marathon app state")
-    local appsRes, err = request("127.0.0.1", 8080, "/v2/apps?embed=apps.tasks&label=DCOS_SERVICE_NAME")
+    local appsRes, err = request("marathon.mesos", 8080, "/v2/apps?embed=apps.tasks&label=DCOS_SERVICE_NAME")
 
     if err then
         ngx.log(ngx.NOTICE, "Marathon app request failed: " .. err)


### PR DESCRIPTION
I am trying to setup the adminrouter locally so I can develop without having to install a real DC/OS cluster somewhere but can stay on my machine. For that I have a some docker containers which quickly spawn a local mesos cluster. On top of that I am currently creating a docker container containing the adminrouter. This works fine.

However the marathon URL is hardcoded to 127.0.0.1 instead of facilitating mesos service discovery. Not sure if that was intentiional but without this change it won't work for me as my marathon is running somewhere else :S
