### PR TITLE
Modify /slave rule to accept /agent too.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -195,12 +195,12 @@ http {
             add_header Expires 0;
         }
 
-        location ~ ^/slave/(?<slaveid>[0-9a-zA-Z-]+)(?<url>.*)$ {
+        location ~ ^/(slave|agent)/(?<slaveid>[0-9a-zA-Z-]+)(?<url>.*)$ {
             access_by_lua 'auth.validate_jwt_or_exit()';
             set $slaveaddr '';
 
             more_clear_input_headers Accept-Encoding;
-            rewrite ^/slave/[0-9a-zA-Z-]+/.*$ $url break;
+            rewrite ^/(slave|agent)/[0-9a-zA-Z-]+/.*$ $url break;
             rewrite_by_lua_file conf/slave.lua;
 
             proxy_set_header        Host $http_host;


### PR DESCRIPTION
The slave->agent rename (in Mesos 0.29+) affects a couple of the endpoints.
For backwards compatibility, this rule should take both old and new terms.