### PR TITLE
Updated maximum client body size

### DIFF
--- a/nginx.agent.conf
+++ b/nginx.agent.conf
@@ -2,6 +2,8 @@ include common/main.conf;
 
 
 http {
+    client_max_body_size 1024M;
+
     upstream dddt {
         server unix:/run/dcos/3dt.sock;
     }

--- a/nginx.master.conf
+++ b/nginx.master.conf
@@ -4,6 +4,8 @@ include common/main.conf;
 http {
     include common/http.conf;
 
+    client_max_body_size 1024M;
+    
     upstream mesos {
         server leader.mesos:5050;
     }


### PR DESCRIPTION
Updated the maximum client body size configuration value to solve a 413 Request Entity Too Large Error in Nginx when uploading a plugin > 1MB in Jenkins.