### PR TITLE
fixed port enforcement

### DIFF
--- a/nginx.master.conf
+++ b/nginx.master.conf
@@ -150,7 +150,7 @@ http {
 
         location ~ ^/service/(?<serviceid>[0-9a-zA-Z-.]+)$ {
             # Append slash and 301-redirect.
-            rewrite ^/service/(.*)$ /service/$1/ permanent;
+            rewrite ^/service/(.*)$ $scheme://$http_host/service/$1/ permanent;
         }
 
         location ~ ^/service/(?<serviceid>[0-9a-zA-Z-.]+)/(?<url>.*) {
@@ -169,8 +169,8 @@ http {
             proxy_set_header        X-Forwarded-Proto $scheme;
 
             proxy_pass $serviceurl;
-            proxy_redirect $servicescheme://$host/service/$serviceid/ /service/$serviceid/;
-            proxy_redirect $servicescheme://$host/ /service/$serviceid/;
+            proxy_redirect $servicescheme://$host/service/$serviceid/ $scheme://$http_host/service/$serviceid/;
+            proxy_redirect $servicescheme://$host/ $scheme://$http_host/service/$serviceid/;
             proxy_redirect / /service/$serviceid/;
 
             # Disable buffering to allow real-time protocols


### PR DESCRIPTION
This allows others nginx to proxy the $http_host so that other proxies can call adminrouter without issue.

Tested this on my end and it works for both the existing adminrouter and haproxy