### PR TITLE
validate jwt for 3dt and pkgpanda API

### DIFF
--- a/common/server.conf
+++ b/common/server.conf
@@ -8,19 +8,3 @@ ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:
 ssl_prefer_server_ciphers on;
 
 server_name dcos.*;
-
-location /system/health/v1 {
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $host;
-    proxy_pass http://dddt;
-}
-
-location /pkgpanda/ {
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-
-    proxy_pass http://pkgpanda/;
-    proxy_redirect http://$http_host/ /pkgpanda/;
-}

--- a/nginx.agent.conf
+++ b/nginx.agent.conf
@@ -16,6 +16,20 @@ http {
 
         listen 61001 default_server;
 
-        
+        location /system/health/v1 {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $host;
+            proxy_pass http://dddt;
+        }
+
+        location /pkgpanda/ {
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_pass http://pkgpanda/;
+            proxy_redirect http://$http_host/ /pkgpanda/;
+        }
     }
 }

--- a/nginx.master.conf
+++ b/nginx.master.conf
@@ -240,6 +240,25 @@ http {
             access_by_lua 'auth.validate_jwt_or_exit()';
             proxy_set_header Host $http_host;
             proxy_pass http://mesos_dns/;
+
+        }
+
+        location /system/health/v1 {
+            access_by_lua 'auth.validate_jwt_or_exit()';
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $host;
+            proxy_pass http://dddt;
+        }
+
+        location /pkgpanda/ {
+            access_by_lua 'auth.validate_jwt_or_exit()';
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_pass http://pkgpanda/;
+            proxy_redirect http://$http_host/ /pkgpanda/;
         }
     }
 }


### PR DESCRIPTION
call `auth.validate_jwt_or_exit()` on all masters for 3dt and pkgpanda API