### PR TITLE
add dcos-log reverse proxy

### DIFF
--- a/common/http.conf
+++ b/common/http.conf
@@ -34,3 +34,7 @@ init_by_lua '
 upstream pkgpanda {
     server unix:/run/dcos/pkgpanda-api.sock;
 }
+
+upstream log {
+    server unix:/run/dcos/dcos-log.sock;
+}

--- a/master/agent.lua
+++ b/master/agent.lua
@@ -9,7 +9,10 @@ end
 for _, agent in ipairs(state["slaves"]) do
     if agent["id"] == ngx.var.agentid then
         local split_pid = agent["pid"]:split("@")
-        ngx.var.agentaddr = split_pid[2]
+        local host_port = split_pid[2]:split(":")
+        ngx.var.agentaddr = host_port[1]
+        ngx.var.agentport = host_port[2]
+
         ngx.log(
             ngx.DEBUG, "agentid / agentaddr:" ..
             ngx.var.agentid .. " / " .. ngx.var.agentaddr

--- a/nginx.agent.conf
+++ b/nginx.agent.conf
@@ -31,5 +31,21 @@ http {
             proxy_pass http://pkgpanda/;
             proxy_redirect http://$http_host/ /pkgpanda/;
         }
+
+        location /system/logs/v1/ {
+            proxy_buffering off;
+            proxy_cache off;
+
+            # make event source work with nginx
+            # http://stackoverflow.com/questions/13672743/eventsource-server-sent-events-through-nginx
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            chunked_transfer_encoding off;
+
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_pass http://log/;
+        }
     }
 }

--- a/nginx.master.conf
+++ b/nginx.master.conf
@@ -137,6 +137,7 @@ http {
         location ~ ^/(slave|agent)/(?<agentid>[0-9a-zA-Z-]+)(?<url>.*)$ {
             access_by_lua 'auth.validate_jwt_or_exit()';
             set $agentaddr '';
+            set $agentport '';
 
             more_clear_input_headers Accept-Encoding;
             rewrite ^/(slave|agent)/[0-9a-zA-Z-]+/.*$ $url break;
@@ -147,7 +148,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
 
-            proxy_pass http://$agentaddr;
+            proxy_pass http://$agentaddr:$agentport;
         }
 
         location ~ ^/service/(?<serviceid>[0-9a-zA-Z-.]+)$ {
@@ -259,6 +260,47 @@ http {
 
             proxy_pass http://pkgpanda/;
             proxy_redirect http://$http_host/ /pkgpanda/;
+        }
+
+        location /system/logs/v1/ {
+            access_by_lua 'auth.validate_jwt_or_exit()';
+            proxy_buffering off;
+            proxy_cache off;
+
+            # make event source work with nginx
+            # http://stackoverflow.com/questions/13672743/eventsource-server-sent-events-through-nginx
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            chunked_transfer_encoding off;
+
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_pass http://log/;
+        }
+
+        location ~ ^/system/logs/v1/(slave|agent)/(?<agentid>[0-9a-zA-Z-]+)(?<url>.*)$ {
+            access_by_lua 'auth.validate_jwt_or_exit()';
+            set $agentaddr '';
+            more_clear_input_headers Accept-Encoding;
+            rewrite ^/(slave|agent)/[0-9a-zA-Z-]+/.*$ $url break;
+            rewrite_by_lua_file conf/master/agent.lua;
+
+            proxy_buffering off;
+            proxy_cache off;
+
+            # make nginx with with server sent events
+            # http://stackoverflow.com/questions/13672743/eventsource-server-sent-events-through-nginx
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            chunked_transfer_encoding off;
+
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_pass http://$agentaddr:61001/system/logs/v1/$url$is_args$query_string;
         }
     }
 }


### PR DESCRIPTION
`dcos-log` https://github.com/dcos/dcos-log is an HTTP server over
systemd journal. dcos-log supports server-sent events for live log pushing
that is why we should disable nginx buffering. dcos-log will be deployed as a
pkgpanda package on all nodes: masters and agents/public agents.

In open DC/OS we are using boolean authorization. We should allow access to
service to any user who is authenticated.