### PR TITLE
Switch all proxy sites to use the same set of common headers

### DIFF
--- a/nginx.agent.conf
+++ b/nginx.agent.conf
@@ -21,16 +21,12 @@ http {
         listen 61001 default_server;
 
         location /system/health/v1 {
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header Host $host;
+            include common/proxy-headers.conf;
             proxy_pass http://dddt;
         }
 
         location /pkgpanda/ {
-            proxy_set_header Host $http_host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            include common/proxy-headers.conf;
 
             proxy_pass http://pkgpanda/;
             proxy_redirect http://$http_host/ /pkgpanda/;
@@ -42,11 +38,9 @@ http {
 
             proxy_pass http://log/;
         }
-        
+
         location /system/v1/metrics/ {
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header Host $host;
+            include common/proxy-headers.conf;
             proxy_pass http://metrics/;
         }
     }

--- a/nginx.master.conf
+++ b/nginx.master.conf
@@ -73,16 +73,14 @@ http {
         }
 
         location /acs/api/v1/auth/ {
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header Host $http_host;
+            include common/proxy-headers.conf;
             proxy_pass http://auth;
         }
 
         location /acs/api/v1 {
             # Enforce access restriction to Auth API.
             access_by_lua 'auth.validate_jwt_or_exit()';
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header Host $http_host;
+            include common/proxy-headers.conf;
             proxy_pass http://auth;
             # Instruct user agent to not cache the response.
             # Ref: http://stackoverflow.com/a/2068407/145400
@@ -97,19 +95,19 @@ http {
 
         location /mesos/ {
             access_by_lua 'auth.validate_jwt_or_exit()';
-            proxy_set_header Host $http_host;
+            include common/proxy-headers.conf;
             proxy_pass http://mesos/;
         }
 
         location /package/ {
             access_by_lua 'auth.validate_jwt_or_exit()';
-            proxy_set_header Host $http_host;
+            include common/proxy-headers.conf;
             proxy_pass http://cosmos/package/;
         }
 
         location /capabilities {
             access_by_lua 'auth.validate_jwt_or_exit()';
-            proxy_set_header Host $http_host;
+            include common/proxy-headers.conf;
             proxy_pass http://cosmos/capabilities;
         }
 
@@ -134,7 +132,7 @@ http {
 
         location /navstar/lashup/key {
             access_by_lua 'auth.validate_jwt_or_exit()';
-            proxy_set_header Host $http_host;
+            include common/proxy-headers.conf;
             proxy_pass http://navstar/lashup/key;
         }
 
@@ -147,17 +145,10 @@ http {
             rewrite ^/(slave|agent)/[0-9a-zA-Z-]+/.*$ $url break;
             rewrite_by_lua_file conf/master/agent.lua;
 
-            proxy_set_header Host $http_host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            include common/proxy-headers.conf;
+            include common/server-sent-events.conf;
 
             proxy_pass http://$agentaddr:$agentport;
-
-            # Supports chunked encoding and stream for debugging API
-            proxy_http_version 1.1;
-            proxy_request_buffering off;
-            proxy_buffering off;
         }
 
         location ~ ^/service/(?<serviceid>[0-9a-zA-Z-.]+)$ {
@@ -175,10 +166,7 @@ http {
             rewrite ^/service/[0-9a-zA-Z-.]+/?.*$ /$url break;
             rewrite_by_lua_file conf/master/service.lua;
 
-            proxy_set_header        Host $http_host;
-            proxy_set_header        X-Real-IP $remote_addr;
-            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header        X-Forwarded-Proto $scheme;
+            include common/proxy-headers.conf;
 
             proxy_pass $serviceurl;
             proxy_redirect $servicescheme://$host/service/$serviceid/ /service/$serviceid/;
@@ -201,8 +189,7 @@ http {
 
         # TODO split this into its own file
         location /dcos-metadata/ui-config.json {
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header Host $http_host;
+            include common/proxy-headers.conf;
             proxy_pass http://auth;
         }
 
@@ -227,7 +214,7 @@ http {
             # Enforce access restriction. Auth-wise, treat /marathon*
             # equivalently to /service/marathon*.
             access_by_lua 'auth.validate_jwt_or_exit()';
-            proxy_set_header Host $http_host;
+            include common/proxy-headers.conf;
             proxy_pass http://marathon/;
         }
 
@@ -248,24 +235,20 @@ http {
 
         location /mesos_dns/ {
             access_by_lua 'auth.validate_jwt_or_exit()';
-            proxy_set_header Host $http_host;
+            include common/proxy-headers.conf;
             proxy_pass http://mesos_dns/;
 
         }
 
         location /system/health/v1 {
             access_by_lua 'auth.validate_jwt_or_exit()';
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header Host $host;
+            include common/proxy-headers.conf;
             proxy_pass http://dddt;
         }
 
         location /pkgpanda/ {
             access_by_lua 'auth.validate_jwt_or_exit()';
-            proxy_set_header Host $http_host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            include common/proxy-headers.conf;
 
             proxy_pass http://pkgpanda/;
             proxy_redirect http://$http_host/ /pkgpanda/;
@@ -302,12 +285,10 @@ http {
 
             proxy_pass http://$agentaddr:61001/system/v1/$url$is_args$query_string;
         }
-        
+
         location /system/v1/metrics/ {
             access_by_lua 'auth.validate_jwt_or_exit()';
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header Host $host;
+            include common/proxy-headers.conf;
             proxy_pass http://metrics/;
         }
     }


### PR DESCRIPTION
Unifies the proxying behavior for everywhere we were doing proxy_set_headers. Takes us from 45 proxy_set_header instances to 7. Overall goal is that we have less unnecessary variation inside the product.

Might break things, might not. Let's find out!

cc: @vespian
