### PR TITLE
Disable buffering to mesos agent API and use HTTP/1.1

### DIFF
--- a/nginx.master.conf
+++ b/nginx.master.conf
@@ -153,6 +153,11 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
 
             proxy_pass http://$agentaddr:$agentport;
+
+            # Supports chunked encoding and stream for debugging API
+            proxy_http_version 1.1;
+            proxy_request_buffering off;
+            proxy_buffering off;
         }
 
         location ~ ^/service/(?<serviceid>[0-9a-zA-Z-.]+)$ {


### PR DESCRIPTION
This is required for debugging to work. 