### PR TITLE
Don't override host in webui_url.

### DIFF
--- a/master/service.lua
+++ b/master/service.lua
@@ -31,14 +31,6 @@ for _, framework in ipairs(state["frameworks"]) do
     else
       local parsed_webui_url = url.parse(webui_url)
 
-      local pid = framework["pid"]
-      if pid then
-        local split_pid = pid:split("@")
-        local split_ipport = split_pid[2]:split(":")
-        local host = split_ipport[1]
-        parsed_webui_url.host = host
-      end
-
       if parsed_webui_url.path == "/" then
         parsed_webui_url.path = ""
       end


### PR DESCRIPTION
This was breaking the Elastic framework, which was running its UI in a separate Kibana container, that could be scheduled on a different host than the framework itself.