### PR TITLE
Disable buffering to mesos agent API and use HTTP/1.1

### DIFF
--- a/nginx.master.conf
+++ b/nginx.master.conf
@@ -163,6 +163,11 @@ http {
             include common/proxy-headers.conf;
             include common/server-sent-events.conf;
 
+            # Supports chunked encoding and stream for debugging API
+            proxy_http_version 1.1;
+            proxy_request_buffering off;
+            proxy_buffering off;
+
             proxy_pass http://$agentaddr:$agentport;
         }
 


### PR DESCRIPTION
Reverts accidental overwrite by https://github.com/dcos/adminrouter/commit/7176d4b6107115eea606a2cf97c6044137848f17#diff-8a636580686895dc929d495101122338L157