### PR TITLE
DCOS/11918 Make AR configuration more test-harness friendly

### DIFF
--- a/common/auth.lua
+++ b/common/auth.lua
@@ -38,7 +38,7 @@ if key_file_path == nil then
     ngx.log(ngx.WARN, "SECRET_KEY_FILE_PATH not set.")
 else
     ngx.log(ngx.NOTICE, "Reading secret key from `" .. key_file_path .. "`.")
-    SECRET_KEY = util.get_stripped_first_line_from_file(key_file_path)
+    SECRET_KEY = util.get_file_content(key_file_path)
     if (SECRET_KEY == nil or SECRET_KEY == '') then
         -- Normalize to nil, for simplified subsequent per-request check.
         SECRET_KEY = nil
@@ -116,7 +116,7 @@ local function validate_jwt_or_exit()
     -- .verified is False even for messed up tokens whereas .valid can be nil.
     -- So, use .verified as reference.
     if jwt_obj.verified == false then
-        ngx.log(ngx.NOTICE, "Invalid token. Reason: ".. jwt_obj.reason)
+        ngx.log(ngx.NOTICE, "Invalid token. Reason: `".. jwt_obj.reason.."`")
         return exit_401()
     end
 

--- a/nginx.master.conf
+++ b/nginx.master.conf
@@ -23,19 +23,19 @@ http {
     }
 
     upstream exhibitor {
-        server localhost:8181;
+        server 127.0.0.1:8181;
     }
 
     upstream cosmos {
-        server localhost:7070;
+        server 127.0.0.1:7070;
     }
 
     upstream auth {
-        server localhost:8101;
+        server 127.0.0.1:8101;
     }
 
     upstream dddt {
-        server localhost:1050;
+        server 127.0.0.1:1050;
     }
 
     upstream metrics {
@@ -43,7 +43,7 @@ http {
     }
 
     upstream navstar {
-        server localhost:62080;
+        server 127.0.0.1:62080;
     }
 
     proxy_cache_path /tmp/nginx-mesos-cache levels=1:2 keys_zone=mesos:1m inactive=10m;

--- a/resty/jwt-validators.lua
+++ b/resty/jwt-validators.lua
@@ -1,0 +1,384 @@
+local _M = {_VERSION="0.1.5"}
+
+--[[
+  This file defines "validators" to be used in validating a spec.  A "validator" is simply a function with
+  a signature that matches:
+
+    function(val, claim, jwt_json)
+
+  This function returns either true or false.  If a validator needs to give more information on why it failed,
+  then it can also raise an error (which will be used in the "reason" part of the validated jwt_obj).  If a
+  validator returns nil, then it is assumed to have passed (same as returning true) and that you just forgot
+  to actually return a value.
+
+  There is a special claim name of "__jwt" that can be used to validate the entire jwt_obj.
+
+  "val" is the value being tested.  It may be nil if the claim doesn't exist in the jwt_obj.  If the function
+  is being called for the "__jwt" claim, then "val" will contain a deep clone of the full jwt object.
+
+  "claim" is the claim that is being tested.  It is passed in just in case a validator needs to do additional
+  checks.  It will be the string "__jwt" if the validator is being called for the entire jwt_object.
+
+  "jwt_json" is a json-encoded representation of the full object that is being tested.  It will never be nil,
+  and can always be decoded using cjson.decode(jwt_json).
+]]--
+
+
+--[[
+    A function which will define a validator.  It creates both "opt_" and required (non-"opt_") 
+    versions.  The function that is passed in is the *optional* version.
+]]--
+local function define_validator(name, fx)
+  _M["opt_" .. name] = fx
+  _M[name] = function(...) return _M.chain(_M.required(), fx(...)) end
+end
+
+-- Validation messages
+local messages = {
+  nil_validator = "Cannot create validator for nil %s.",
+  wrong_type_validator = "Cannot create validator for non-%s %s.",
+  empty_table_validator = "Cannot create validator for empty table %s.",
+  wrong_table_type_validator = "Cannot create validator for non-%s table %s.",
+  required_claim = "'%s' claim is required.",
+  wrong_type_claim = "'%s' is malformed.  Expected to be a %s.",
+  missing_claim = "Missing one of claims - [ %s ]."
+}
+
+-- Local function to make sure that a value is non-nil or raises an error
+local function ensure_not_nil(v, e, ...)
+  return v ~= nil and v or error(string.format(e, ...), 0)
+end
+
+-- Local function to make sure that a value is the given type
+local function ensure_is_type(v, t, e, ...)
+  return type(v) == t and v or error(string.format(e, ...), 0)
+end
+
+-- Local function to make sure that a value is a (non-empty) table
+local function ensure_is_table(v, e, ...)
+  ensure_is_type(v, "table", e, ...)
+  return ensure_not_nil(next(v), e, ...)
+end
+
+-- Local function to make sure all entries in the table are the given type
+local function ensure_is_table_type(v, t, e, ...)
+  if v ~= nil then
+    ensure_is_table(v, e, ...)
+    for _,val in ipairs(v) do
+      ensure_is_type(val, t, e, ...)
+    end
+  end
+  return v
+end
+
+-- Local function to ensure that a number is non-negative (positive or 0)
+local function ensure_is_non_negative(v, e, ...)
+  if v ~= nil then
+    ensure_is_type(v, "number", e, ...)
+    if v >= 0 then
+      return v
+    else
+      error(string.format(e, ...), 0)
+    end
+  end
+end
+
+-- A local function which returns simple equality
+local function equality_function(val, check)
+  return val == check
+end
+
+-- A local function which returns string match
+local function string_match_function(val, pattern)
+  return string.match(val, pattern) ~= nil
+end
+
+-- A local function which returns numeric greater than comparison
+local function greater_than_function(val, check)
+  return val > check
+end
+
+-- A local function which returns numeric greater than or equal comparison
+local function greater_than_or_equal_function(val, check)
+  return val >= check
+end
+
+-- A local function which returns numeric less than comparison
+local function less_than_function(val, check)
+  return val < check
+end
+
+-- A local function which returns numeric less than or equal comparison
+local function less_than_or_equal_function(val, check)
+  return val <= check
+end
+
+
+--[[
+    Returns a validator that chains the given functions together, one after 
+    another - as long as they keep passing their checks.
+]]--
+function _M.chain(...)
+  local chain_functions = {...}
+  for _, fx in ipairs(chain_functions) do
+    ensure_is_type(fx, "function", messages.wrong_type_validator, "function", "chain_function")
+  end
+
+  return function(val, claim, jwt_json)
+    for _, fx in ipairs(chain_functions) do
+      if fx(val, claim, jwt_json) == false then
+        return false
+      end
+    end
+    return true
+  end
+end
+
+--[[
+    Returns a validator that returns false if a value doesn't exist.  If
+    the value exists and a chain_function is specified, then the value of 
+        chain_function(val, claim, jwt_json)
+    will be returned, otherwise, true will be returned.  This allows for 
+    specifying that a value is both required *and* it must match some 
+    additional check.  This function will be used in the "required_*" shortcut
+    functions for simplification.
+]]--
+function _M.required(chain_function)
+  if chain_function ~= nil then
+    return _M.chain(_M.required(), chain_function)
+  end
+  
+  return function(val, claim, jwt_json)
+    ensure_not_nil(val, messages.required_claim, claim)
+    return true
+  end
+end
+
+--[[
+    Returns a validator which errors with a message if *NONE* of the given claim
+    keys exist.  It is expected that this function is used against a full jwt object.  
+    The claim_keys must be a non-empty table of strings.
+]]--
+function _M.require_one_of(claim_keys)
+  ensure_not_nil(claim_keys, messages.nil_validator, "claim_keys")
+  ensure_is_type(claim_keys, "table", messages.wrong_type_validator, "table", "claim_keys")
+  ensure_is_table(claim_keys, messages.empty_table_validator, "claim_keys")
+  ensure_is_table_type(claim_keys, "string", messages.wrong_table_type_validator, "string", "claim_keys")
+  
+  return function(val, claim, jwt_json)
+    ensure_is_type(val, "table", messages.wrong_type_claim, claim, "table")
+    ensure_is_type(val.payload, "table", messages.wrong_type_claim, claim .. ".payload", "table")
+    
+    for i, v in ipairs(claim_keys) do
+      if val.payload[v] ~= nil then return true end
+    end
+    
+    error(string.format(messages.missing_claim, table.concat(claim_keys, ", ")), 0)
+  end
+end
+
+--[[
+    Returns a validator that checks if the result of calling the given function for
+    the tested value and the check value returns true.  The value of check_val and 
+    check_function cannot be nil.  The optional name is used for error messages and 
+    defaults to "check_value".  The optional check_type is used to make sure that 
+    the check type matches and defaults to type(check_val).  The first parameter 
+    passed to check_function will *never* be nil (check succeeds if value is nil).  
+    Use the required version to fail on nil.  If the check_function raises an 
+    error, that will be appended to the error message.
+]]--
+define_validator("check", function(check_val, check_function, name, check_type)
+  name = name or "check_val"
+  ensure_not_nil(check_val, messages.nil_validator, name)
+  
+  ensure_not_nil(check_function, messages.nil_validator, "check_function")
+  ensure_is_type(check_function, "function", messages.wrong_type_validator, "function", "check_function")
+  
+  check_type = check_type or type(check_val)
+  return function(val, claim, jwt_json)
+    if val == nil then return true end
+    
+    ensure_is_type(val, check_type, messages.wrong_type_claim, claim, check_type)
+    return check_function(val, check_val)
+  end
+end)
+
+
+--[[
+    Returns a validator that checks if a value exactly equals the given check_value.
+    If the value is nil, then this check succeeds.  The value of check_val cannot be
+    nil.
+]]--
+define_validator("equals", function(check_val)
+  return _M.opt_check(check_val, equality_function, "check_val")
+end)
+
+
+--[[
+    Returns a validator that checks if a value matches the given pattern.  The value 
+    of pattern must be a string.
+]]--
+define_validator("matches", function (pattern)
+  ensure_is_type(pattern, "string", messages.wrong_type_validator, "string", "pattern")
+  return _M.opt_check(pattern, string_match_function, "pattern", "string")
+end)
+
+
+--[[
+    Returns a validator which calls the given function for each of the given values
+    and the tested value.  If any of these calls return true, then this function
+    returns true.  The value of check_values must be a non-empty table with all the 
+    same types, and the value of check_function must not be nil.  The optional name 
+    is used for error messages and defaults to "check_values".  The optional 
+    check_type is used to make sure that the check type matches and defaults to 
+    type(check_values[1]) - the table type.
+]]--
+define_validator("any_of", function(check_values, check_function, name, check_type, table_type)
+  name = name or "check_values"
+  ensure_not_nil(check_values, messages.nil_validator, name)
+  ensure_is_type(check_values, "table", messages.wrong_type_validator, "table", name)
+  ensure_is_table(check_values, messages.empty_table_validator, name)
+  
+  table_type = table_type or type(check_values[1])
+  ensure_is_table_type(check_values, table_type, messages.wrong_table_type_validator, table_type, name)
+  
+  ensure_not_nil(check_function, messages.nil_validator, "check_function")
+  ensure_is_type(check_function, "function", messages.wrong_type_validator, "function", "check_function")
+  
+  check_type = check_type or table_type
+  return _M.opt_check(check_values, function(v1, v2)
+    for i, v in ipairs(v2) do
+      if check_function(v1, v) then return true end
+    end
+    return false
+  end, name, check_type)
+end)
+
+
+--[[
+    Returns a validator that checks if a value exactly equals any of the given values.
+]]--
+define_validator("equals_any_of", function(check_values)
+  return _M.opt_any_of(check_values, equality_function, "check_values")
+end)
+
+
+--[[
+    Returns a validator that checks if a value matches any of the given patterns.
+]]--
+define_validator("matches_any_of", function(patterns)
+  return _M.opt_any_of(patterns, string_match_function, "patterns", "string", "string")
+end)
+
+
+--[[
+    Returns a validator that checks how a value compares (numerically) to a given 
+    check_value.  The value of check_val cannot be nil and must be a number.
+]]--
+define_validator("greater_than", function(check_val)
+  ensure_is_type(check_val, "number", messages.wrong_type_validator, "number", "check_val")
+  return _M.opt_check(check_val, greater_than_function, "check_val", "number")
+end)
+define_validator("greater_than_or_equal", function(check_val)
+  ensure_is_type(check_val, "number", messages.wrong_type_validator, "number", "check_val")
+  return _M.opt_check(check_val, greater_than_or_equal_function, "check_val", "number")
+end)
+define_validator("less_than", function(check_val)
+  ensure_is_type(check_val, "number", messages.wrong_type_validator, "number", "check_val")
+  return _M.opt_check(check_val, less_than_function, "check_val", "number")
+end)
+define_validator("less_than_or_equal", function(check_val)
+  ensure_is_type(check_val, "number", messages.wrong_type_validator, "number", "check_val")
+  return _M.opt_check(check_val, less_than_or_equal_function, "check_val", "number")
+end)
+
+
+--[[
+    A function to set the leeway (in seconds) used for is_not_before and is_not_expired.  The
+    default is to use 0 seconds
+]]--
+local system_leeway = 0
+function _M.set_system_leeway(leeway)
+  ensure_is_type(leeway, "number", "leeway must be a non-negative number")
+  ensure_is_non_negative(leeway, "leeway must be a non-negative number")
+  system_leeway = leeway
+end
+
+
+--[[
+    A function to set the system clock used for is_not_before and is_not_expired.  The
+    default is to use ngx.now
+]]--
+local system_clock = ngx.now
+function _M.set_system_clock(clock)
+  ensure_is_type(clock, "function", "clock must be a function")
+  
+  -- Check that clock returns the correct value
+  local t = clock()
+  ensure_is_type(t, "number", "clock function must return a non-negative number")
+  ensure_is_non_negative(t, "clock function must return a non-negative number")
+  system_clock = clock
+end
+
+-- Local helper function for date validation
+local function validate_is_date(val, claim, jwt_json)
+  ensure_is_non_negative(val, messages.wrong_type_claim, claim, "positive numeric value")
+  return true
+end
+
+-- Local helper for date formatting
+local function format_date_on_error(date_check_function, error_msg)
+  ensure_is_type(date_check_function, "function", messages.wrong_type_validator, "function", "date_check_function")
+  ensure_is_type(error_msg, "string", messages.wrong_type_validator, "string", error_msg)
+  return function(val, claim, jwt_json)
+    local ret = date_check_function(val, claim, jwt_json)
+    if ret == false then
+      error(string.format("'%s' claim %s %s", claim, error_msg, ngx.http_time(val)), 0)
+    end
+    return true
+  end
+end
+
+--[[
+    Returns a validator that checks if the current time is not before the tested value
+    within the system's leeway.  This means that:
+      val <= (system_clock() + system_leeway).
+]]--
+define_validator("is_not_before", function()
+  return format_date_on_error(
+    _M.chain(validate_is_date, _M.opt_less_than_or_equal(system_clock() + system_leeway)),
+    "not valid until"
+  )
+end)
+
+
+--[[
+    Returns a validator that checks if the current time is not equal to or after the 
+    tested value within the system's leeway.  This means that:
+      val > (system_clock() - system_leeway).
+]]--
+define_validator("is_not_expired", function()
+  return format_date_on_error(
+    _M.chain(validate_is_date, _M.opt_greater_than(system_clock() - system_leeway)),
+    "expired at"
+  )
+end)
+
+
+--[[
+    Returns a validator that checks if the current time is the same as the tested value 
+    within the system's leeway.  This means that:
+      val >= (system_clock() - system_leeway) and val <= (system_clock() + system_leeway).
+]]--
+define_validator("is_at", function()
+  local now = system_clock()
+  return format_date_on_error(
+    _M.chain(validate_is_date, 
+             _M.opt_greater_than_or_equal(now - system_leeway),
+             _M.opt_less_than_or_equal(now + system_leeway)),
+    "is only valid at"
+  )
+end)
+
+
+return _M

--- a/resty/jwt.lua
+++ b/resty/jwt.lua
@@ -1,79 +1,339 @@
-local cjson = require "cjson"
+local cjson = require "cjson.safe"
+local aes = require "resty.aes"
 local evp = require "resty.evp"
 local hmac = require "resty.hmac"
+local resty_random = require "resty.random"
 
-local _M = {_VERSION="0.1.1"}
+local _M = {_VERSION="0.1.5"}
 local mt = {__index=_M}
 
+local string_match= string.match
+local string_rep = string.rep
+local string_format = string.format
+local string_sub = string.sub
+local string_byte = string.byte
+local string_char = string.char
+local table_concat = table.concat
+local ngx_encode_base64 = ngx.encode_base64
+local ngx_decode_base64 = ngx.decode_base64
+local cjson_encode = cjson.encode
+local cjson_decode = cjson.decode
+local tostring = tostring
 
+-- define string constants to avoid string garbage collection
+local str_const = {
+  invalid_jwt= "invalid jwt string",
+  regex_join_msg = "%s.%s",
+  regex_join_delim = "([^%s]+)",
+  regex_split_dot = "%.",
+  regex_jwt_join_str = "%s.%s.%s",
+  raw_underscore  = "raw_",
+  dash = "-",
+  empty = "",
+  dotdot = "..",
+  table  = "table",
+  plus = "+",
+  equal = "=",
+  underscore = "_",
+  slash = "/",
+  header = "header",
+  typ = "typ",
+  JWT = "JWT",
+  JWE = "JWE",
+  payload = "payload",
+  signature = "signature",
+  encrypted_key = "encrypted_key",
+  alg = "alg",
+  enc = "enc",
+  kid = "kid",
+  exp = "exp",
+  nbf = "nbf",
+  iss = "iss",
+  full_obj = "__jwt",
+  AES = "AES",
+  cbc = "cbc",
+  x5c = "x5c",
+  x5u = 'x5u',
+  HS256 = "HS256",
+  HS512 = "HS512",
+  RS256 = "RS256",
+  A128CBC_HS256 = "A128CBC-HS256",
+  A256CBC_HS512 = "A256CBC-HS512",
+  DIR = "dir",
+  reason = "reason",
+  verified = "verified",
+  number = "number",
+  string = "string",
+  funct = "function",
+  boolean = "boolean",
+  table = "table",
+  valid = "valid",
+  valid_issuers = "valid_issuers",
+  lifetime_grace_period = "lifetime_grace_period",
+  require_nbf_claim = "require_nbf_claim",
+  require_exp_claim = "require_exp_claim",
+  internal_error = "internal error",
+  everything_awesome = "everything is awesome~ :p"
+}
+
+-- @function split string
+local function split_string(str, delim, maxNb)
+  local result = {}
+  local sep = string_format(str_const.regex_join_delim, delim)
+  for m in str:gmatch(sep) do
+    result[#result+1]=m
+  end
+  return result
+end
+
+-- @function is nil or boolean
+-- @return true if param is nil or true or false; false otherwise
+local function is_nil_or_boolean(arg_value)
+    if arg_value == nil then
+        return true
+    end
+
+    if type(arg_value) ~= str_const.boolean then
+        return false
+    end
+
+    return true
+end
+
+--@function get the row part
+--@param part_name
+--@param jwt_obj
 local function get_raw_part(part_name, jwt_obj)
-    local raw_part = jwt_obj["raw_" .. part_name]
-    if raw_part == nil then
-        local part = jwt_obj[part_name]
-        if part == nil then
-            error({reason="missing part " .. part_name})
-        end
-        raw_part = _M:jwt_encode(part)
+  local raw_part = jwt_obj[str_const.raw_underscore .. part_name]
+  if raw_part == nil then
+    local part = jwt_obj[part_name]
+    if part == nil then
+      error({reason="missing part " .. part_name})
     end
-    return raw_part
+    raw_part = _M:jwt_encode(part)
+  end
+  return raw_part
 end
 
 
-local function parse(token_str)
-    local basic_jwt = {}
-    local raw_header, raw_payload, signature = string.match(
-        token_str,
-        '([^%.]+)%.([^%.]+)%.([^%.]+)'
-    )
-    local header = _M:jwt_decode(raw_header, true)
-    if not header then
-        error({reason="invalid header: " .. raw_header})
-    end
+--@function decrypt payload
+--@param secret_key to decrypt the payload
+--@param encrypted payload
+--@param encryption algorithm
+--@param iv which was generated while encrypting the payload
+--@return decrypted payloaf
+local function decrypt_payload(secret_key, encrypted_payload, enc, iv_in )
+  local decrypted_payload
+  if enc == str_const.A128CBC_HS256 then
+    local aes_128_cbc_with_iv = assert(aes:new(secret_key, str_const.AES, aes.cipher(128,str_const.cbc), {iv=iv_in} ))
+    decrypted_payload=  aes_128_cbc_with_iv:decrypt(encrypted_payload)
+  elseif enc == str_const.A256CBC_HS512 then
+    local aes_256_cbc_with_iv = assert(aes:new(secret_key, str_const.AES, aes.cipher(256,str_const.cbc), {iv=iv_in} ))
+    decrypted_payload=  aes_256_cbc_with_iv:decrypt(encrypted_payload)
 
-    local payload = _M:jwt_decode(raw_payload, true)
-    if not payload then
-        error({reason="invalid payload: " .. raw_payload})
-    end
+  else
+    return nil, "unsupported enc: " .. enc
+  end
+  if not  decrypted_payload then
+    return nil, "invalid secret key"
+  end
+  return decrypted_payload
+end
 
-    local basic_jwt = {
-        raw_header=raw_header,
-        raw_payload=raw_payload,
-        header=header,
-        payload=payload,
-        signature=signature
-    }
-    return basic_jwt
+-- @function : encrypt payload using given secret
+-- @param secret key to encrypt
+-- @param algortim to use for encryption
+-- @message  : data to be encrypted. It could be lua table or string
+local function encrypt_payload(secret_key, message, enc )
+
+  if enc == str_const.A128CBC_HS256 then
+    local iv_rand =  resty_random.bytes(16,true)
+    local aes_128_cbc_with_iv = assert(aes:new(secret_key, str_const.AES, aes.cipher(128,str_const.cbc), {iv=iv_rand} ))
+    local encrypted = aes_128_cbc_with_iv:encrypt(message)
+    return encrypted, iv_rand
+
+  elseif enc == str_const.A256CBC_HS512 then
+    local iv_rand =  resty_random.bytes(16,true)
+    local aes_256_cbc_with_iv = assert(aes:new(secret_key, str_const.AES, aes.cipher(256,str_const.cbc), {iv=iv_rand} ))
+    local encrypted = aes_256_cbc_with_iv:encrypt(message)
+    return encrypted, iv_rand
+
+  else
+    return nil, nil , "unsupported enc: " .. enc
+  end
+end
+
+--@function hmac_digest : generate hmac digest based on key for input message
+--@param mac_key
+--@param input message
+--@return hmac digest
+local function hmac_digest(enc, mac_key, message)
+  if enc == str_const.A128CBC_HS256 then
+    return hmac:new(mac_key, hmac.ALGOS.SHA256):final(message)
+  elseif enc == str_const.A256CBC_HS512 then
+    return hmac:new(mac_key, hmac.ALGOS.SHA512):final(message)
+  else
+    error({reason="unsupported enc: " .. enc})
+  end
+end
+
+--@function dervice keys: it generates key if null based on encryption algorithm
+--@param encryption type
+--@param secret key
+--@return secret key, mac key and encryption key
+local function derive_keys(enc, secret_key)
+  local mac_key_len, enc_key_len = 16, 16
+
+  if enc == str_const.A128CBC_HS256 then
+    mac_key_len, enc_key_len = 16, 16
+  elseif enc == str_const.A256CBC_HS512 then
+    mac_key_len, enc_key_len = 32, 32
+  end
+
+  local secret_key_len = mac_key_len + enc_key_len
+
+  if not secret_key then
+    secret_key =  resty_random.bytes(secret_key_len, true)
+  end
+
+  if #secret_key ~= secret_key_len then
+    error({reason="The pre-shared content key must be ".. secret_key_len})
+  end
+
+  local mac_key = string_sub(secret_key, 1, mac_key_len)
+  local enc_key = string_sub(secret_key, enc_key_len + 1)
+  return secret_key, mac_key, enc_key
+end
+
+--@function parse_jwe
+--@param pre-shared key
+--@encoded-header
+local function parse_jwe(preshared_key, encoded_header, encoded_encrypted_key, encoded_iv, encoded_cipher_text, encoded_auth_tag)
+
+
+  local header = _M:jwt_decode(encoded_header, true)
+  if not header then
+    error({reason="invalid header: " .. encoded_header})
+  end
+
+  local key, mac_key, enc_key = derive_keys(header.enc, preshared_key)
+
+  -- use preshared key if given otherwise decrypt the encoded key
+  if not preshared_key then
+    local encrypted_key = _M:jwt_decode(encoded_encrypted_key)
+    if header.alg == str_const.DIR then
+      error({reason="preshared key must not ne null"})
+    else  -- implement algorithm to decrypt the key
+      error({reason="invalid algorithm: " .. header.alg})
+    end
+  end
+
+  local cipher_text = _M:jwt_decode(encoded_cipher_text)
+  local iv =  _M:jwt_decode(encoded_iv)
+
+  local basic_jwe = {
+    internal = {
+      encoded_header = encoded_header,
+      cipher_text = cipher_text,
+      key = key,
+      iv = iv
+    },
+    header=header,
+    signature=_M:jwt_decode(encoded_auth_tag)
+  }
+
+  local json_payload, err = decrypt_payload(enc_key, cipher_text, header.enc, iv)
+  if not json_payload then
+    basic_jwe.reason = err
+
+  else
+    basic_jwe.payload = cjson_decode(json_payload)
+    basic_jwe.internal.json_payload=json_payload
+  end
+  return basic_jwe
+end
+
+-- @function parse_jwt
+-- @param encoded header
+-- @param encoded
+-- @param signature
+-- @return jwt table
+local function parse_jwt(encoded_header, encoded_payload, signature)
+  local header = _M:jwt_decode(encoded_header, true)
+  if not header then
+    error({reason="invalid header: " .. encoded_header})
+  end
+
+  local payload = _M:jwt_decode(encoded_payload, true)
+  if not payload then
+    error({reason="invalid payload: " .. encoded_payload})
+  end
+
+  local basic_jwt = {
+    raw_header=encoded_header,
+    raw_payload=encoded_payload,
+    header=header,
+    payload=payload,
+    signature=signature
+  }
+  return basic_jwt
+
+end
+
+-- @function parse token - this can be JWE or JWT token
+-- @param token string
+-- @return jwt/jwe tables
+local function parse(secret, token_str)
+  local tokens = split_string(token_str, str_const.regex_split_dot)
+  local num_tokens = #tokens
+  if num_tokens == 3 then
+    return  parse_jwt(tokens[1], tokens[2], tokens[3])
+  elseif num_tokens == 4  then
+    return parse_jwe(secret, tokens[1], "", tokens[2], tokens[3],  tokens[4])
+  elseif num_tokens == 5 then
+    return parse_jwe(secret, tokens[1], tokens[2], tokens[3],  tokens[4], tokens[5])
+  else
+    error({reason=str_const.invalid_jwt})
+  end
 end
 
 
+--@function jwt encode : it converts into base64 encoded string. if input is a table, it convets into
+-- json before converting to base64 string
+--@param payloaf
+--@return base64 encoded payloaf
 function _M.jwt_encode(self, ori)
-    if type(ori) == "table" then
-        ori = cjson.encode(ori)
-    end
-    return ngx.encode_base64(ori):gsub("+", "-"):gsub("/", "_"):gsub("=", "")
+  if type(ori) == str_const.table then
+    ori = cjson_encode(ori)
+  end
+  return ngx.encode_base64(ori):gsub(str_const.plus, str_const.dash):gsub(str_const.slash, str_const.underscore):gsub(str_const.equal, str_const.empty)
 end
 
 
+
+--@function jwt decode : decode bas64 encoded string
 function _M.jwt_decode(self, b64_str, json_decode)
-    local reminder = #b64_str % 4
-    if reminder > 0 then
-        b64_str = b64_str .. string.rep("=", 4 - reminder)
-    end
-    local data = ngx.decode_base64(b64_str)
-    if not data then
-        return nil
-    end
-    if json_decode then
-        data = cjson.decode(data)
-    end
-    return data
+  b64_str = b64_str:gsub(str_const.dash, str_const.plus):gsub(str_const.underscore, str_const.slash)
+
+  local reminder = #b64_str % 4
+  if reminder > 0 then
+    b64_str = b64_str .. string_rep(str_const.equal, 4 - reminder)
+  end
+  local data = ngx_decode_base64(b64_str)
+  if not data then
+    return nil
+  end
+  if json_decode then
+    data = cjson_decode(data)
+  end
+  return data
 end
 
 --- Initialize the trusted certs
 -- During RS256 verify, we'll make sure the
 -- cert was signed by one of these
 function _M.set_trusted_certs_file(self, filename)
-    self.trusted_certs_file = filename
+  self.trusted_certs_file = filename
 end
 _M.trusted_certs_file = nil
 
@@ -84,175 +344,485 @@ _M.trusted_certs_file = nil
 --                     If the table is non-nil, during
 --                     verify, the alg must be in the table
 function _M.set_alg_whitelist(self, algorithms)
-    self.alg_whitelist = algorithms
+  self.alg_whitelist = algorithms
 end
+
 _M.alg_whitelist = nil
 
+
+--- Returns the list of default validations that will be
+--- applied upon the verification of a jwt.
+function _M.get_default_validation_options(self)
+  return { }
+end
+
+--- Set a function used to retrieve the content of x5u urls
+--
+-- @param retriever_function - A pointer to a function. This function should be
+--                             defined to accept three string parameters. First one
+--                             will be the value of the 'x5u' attribute. Second
+--                             one will be the value of the 'iss' attribute, would
+--                             it be defined in the jwt. Third one will be the value
+--                             of the 'iss' attribute, would it be defined in the jwt.
+--                             This function should return the matching certificate.
+function _M.set_x5u_content_retriever(self, retriever_function)
+  if type(retriever_function) ~= str_const.funct then
+    error("'retriever_function' is expected to be a function", 0)
+  end
+  self.x5u_content_retriever = retriever_function
+end
+
+_M.x5u_content_retriever = nil
+
+-- https://tools.ietf.org/html/rfc7516#appendix-B.3
+-- TODO: do it in lua way
+local function binlen(s)
+  if type(s) ~= 'string' then return end
+
+  local len = 8 * #s
+
+  return string_char(len / 0x0100000000000000 % 0x100)
+      .. string_char(len / 0x0001000000000000 % 0x100)
+      .. string_char(len / 0x0000010000000000 % 0x100)
+      .. string_char(len / 0x0000000100000000 % 0x100)
+      .. string_char(len / 0x0000000001000000 % 0x100)
+      .. string_char(len / 0x0000000000010000 % 0x100)
+      .. string_char(len / 0x0000000000000100 % 0x100)
+      .. string_char(len / 0x0000000000000001 % 0x100)
+end
+
+--@function sign jwe payload
+--@param secret key : if used pre-shared or RSA key
+--@param  jwe payload
+--@return jwe token
+local function sign_jwe(secret_key, jwt_obj)
+  local header = jwt_obj.header
+  local enc = header.enc
+
+  local key, mac_key, enc_key = derive_keys(enc, secret_key)
+  local json_payload = cjson_encode(jwt_obj.payload)
+  local cipher_text, iv, err = encrypt_payload(enc_key, json_payload, enc)
+  if err then
+    error({reason="error while encrypting payload. Error: " .. err})
+  end
+  local alg = header.alg
+
+  if alg ~= str_const.DIR then
+    error({reason="unsupported alg: " .. tostring(alg)})
+  end
+  -- remove type
+  if header.typ then
+    header.typ = nil
+  end
+  local encoded_header = _M:jwt_encode(header)
+
+  local encoded_header_length = binlen(encoded_header)
+  local mac_input = table_concat({encoded_header , iv, cipher_text , encoded_header_length})
+  local mac = hmac_digest(enc, mac_key, mac_input)
+  -- TODO: implement logic for creating enc key and mac key and then encrypt key
+  local encrypted_key
+  if alg ==  str_const.DIR then
+    encrypted_key = ""
+  else
+    error({reason="unsupported alg: " .. alg})
+  end
+  local auth_tag = string_sub(mac, 1, #mac/2)
+  local jwe_table = {encoded_header, _M:jwt_encode(encrypted_key), _M:jwt_encode(iv),
+    _M:jwt_encode(cipher_text),   _M:jwt_encode(auth_tag)}
+  return table_concat(jwe_table, ".", 1, 5)
+end
+
+--@function get_secret_str  : returns the secret if it is a string, or the result of a function
+--@param either the string secret or a function that takes a string parameter and returns a string or nil
+--@param  jwt payload
+--@return the secret as a string or as a function
+local function get_secret_str(secret_or_function, jwt_obj)
+  if type(secret_or_function) == str_const.funct then
+    -- Only use with hmac algorithms
+    local alg = jwt_obj[str_const.header][str_const.alg]
+    if alg ~= str_const.HS256 and alg ~= str_const.HS512 then
+      error({reason="secret function can only be used with hmac alg: " .. alg})
+    end
+
+    -- Pull out the kid value from the header
+    local kid_val = jwt_obj[str_const.header][str_const.kid]
+    if kid_val == nil then
+      error({reason="secret function specified without kid in header"})
+    end
+
+    -- Call the function
+    return secret_or_function(kid_val) or error({reason="function returned nil for kid: " .. kid_val})
+  elseif type(secret_or_function) == str_const.string then
+    -- Just return the string
+    return secret_or_function
+  else
+    -- Throw an error
+    error({reason="invalid secret type (must be string or function)"})
+  end
+end
+
+--@function sign  : create a jwt/jwe signature from jwt_object
+--@param secret key
+--@param jwt/jwe payload
 function _M.sign(self, secret_key, jwt_obj)
-    -- header typ check
-    local typ = jwt_obj["header"]["typ"]
-    if typ ~= "JWT" then
-        error({reason="invalid typ: " .. typ})
+  -- header typ check
+  local typ = jwt_obj[str_const.header][str_const.typ]
+  -- Optional header typ check [See http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-5.1]
+  if typ ~= nil then
+    if typ ~= str_const.JWT and typ ~= str_const.JWE then
+      error({reason="invalid typ: " .. typ})
+    end
+  end
+
+  if typ == str_const.JWE or jwt_obj.header.enc then
+    return sign_jwe(secret_key, jwt_obj)
+  end
+  -- header alg check
+  local raw_header = get_raw_part(str_const.header, jwt_obj)
+  local raw_payload = get_raw_part(str_const.payload, jwt_obj)
+  local message = string_format(str_const.regex_join_msg, raw_header , raw_payload)
+
+  local alg = jwt_obj[str_const.header][str_const.alg]
+  local signature = ""
+  if alg == str_const.HS256 then
+    local secret_str = get_secret_str(secret_key, jwt_obj)
+    signature = hmac:new(secret_str, hmac.ALGOS.SHA256):final(message)
+  elseif alg == str_const.HS512 then
+    local secret_str = get_secret_str(secret_key, jwt_obj)
+    signature = hmac:new(secret_str, hmac.ALGOS.SHA512):final(message)
+  elseif alg == str_const.RS256 then
+    local signer, err = evp.RSASigner:new(secret_key)
+    if not signer then
+      error({reason="signer error: " .. err})
+    end
+    signature = signer:sign(message, evp.CONST.SHA256_DIGEST)
+  else
+    error({reason="unsupported alg: " .. alg})
+  end
+  -- return full jwt string
+  return string_format(str_const.regex_join_msg, message , _M:jwt_encode(signature))
+
+end
+
+--@function load jwt
+--@param jwt string token
+--@param secret
+function _M.load_jwt(self, jwt_str, secret)
+  local success, ret = pcall(parse, secret, jwt_str)
+  if not success then
+    return {
+      valid=false,
+      verified=false,
+      reason=ret[str_const.reason] or str_const.invalid_jwt
+    }
+  end
+
+  local jwt_obj = ret
+  jwt_obj[str_const.verified] = false
+  jwt_obj[str_const.valid] = true
+  return jwt_obj
+end
+
+--@function verify jwe object
+--@param secret
+--@param jwt object
+--@return jwt object with reason whether verified or not
+local function verify_jwe_obj(secret, jwt_obj)
+  local key, mac_key, enc_key = derive_keys(jwt_obj.header.enc, jwt_obj.internal.key)
+  local encoded_header = jwt_obj.internal.encoded_header
+
+  local encoded_header_length = binlen(encoded_header)
+  local mac_input = table_concat({encoded_header , jwt_obj.internal.iv, jwt_obj.internal.cipher_text , encoded_header_length})
+  local mac = hmac_digest(jwt_obj.header.enc, mac_key,  mac_input)
+  local auth_tag = string_sub(mac, 1, #mac/2)
+
+  if auth_tag ~= jwt_obj.signature then
+    jwt_obj[str_const.reason] = "signature mismatch: " ..
+    tostring(jwt_obj[str_const.signature])
+
+  end
+  jwt_obj.internal = nil
+  jwt_obj.signature = nil
+
+  if not jwt_obj[str_const.reason] then
+    jwt_obj[str_const.verified] = true
+    jwt_obj[str_const.reason] = str_const.everything_awesome
+  end
+
+  return jwt_obj
+end
+
+--@function extract certificate
+--@param jwt object
+--@return decoded certificate
+local function extract_certificate(jwt_obj, x5u_content_retriever)
+  local x5c = jwt_obj[str_const.header][str_const.x5c]
+  if x5c ~= nil and x5c[1] ~= nil then
+    -- TODO Might want to add support for intermediaries that we
+    -- don't have in our trusted chain (items 2... if present)
+    local cert_str = ngx_decode_base64(x5c[1])
+    if not cert_str then
+      jwt_obj[str_const.reason] = "Malformed x5c header"
+    end
+
+    return cert_str
+  end
+
+  local x5u = jwt_obj[str_const.header][str_const.x5u]
+  if x5u ~= nil then
+    -- TODO Ensure the url starts with https://
+    -- cf. https://tools.ietf.org/html/rfc7517#section-4.6
+
+    if x5u_content_retriever == nil then
+      jwt_obj[str_const.reason] = "No function has been provided to retrieve the content pointed at by the 'x5u'."
+      return nil
+    end
+
+    -- TODO Maybe validate the url against an optional list whitelisted url prefixes?
+    -- cf. https://news.ycombinator.com/item?id=9302394
+
+    local iss = jwt_obj[str_const.payload][str_const.iss]
+    local kid = jwt_obj[str_const.header][str_const.kid]
+    local success, ret = pcall(x5u_content_retriever, x5u, iss, kid)
+
+    if not success then
+      jwt_obj[str_const.reason] = "An error occured while invoking the x5u_content_retriever function."
+      return nil
+    end
+
+    return ret
+  end
+
+  -- TODO When both x5c and x5u are defined, the implementation should
+  -- ensure their content match
+  -- cf. https://tools.ietf.org/html/rfc7517#section-4.6
+
+  jwt_obj[str_const.reason] = "Unsupported RS256 key model"
+  return nil
+  -- TODO - Implement jwk and kid based models...
+end
+
+local function get_claim_spec_from_legacy_options(self, options)
+  local claim_spec = { }
+  local jwt_validators = require "resty.jwt-validators"
+
+  if options[str_const.valid_issuers] ~= nil then
+    claim_spec[str_const.iss] = jwt_validators.equals_any_of(options[str_const.valid_issuers])
+  end
+
+  if options[str_const.lifetime_grace_period] ~= nil then
+    jwt_validators.set_system_leeway(options[str_const.lifetime_grace_period] or 0)
+
+    -- If we have a leeway set, then either an NBF or an EXP should also exist requireds are added below
+    if options[str_const.require_nbf_claim] ~= true and options[str_const.require_exp_claim] ~= true then
+      claim_spec[str_const.full_obj] = jwt_validators.require_one_of({ str_const.nbf, str_const.exp })
+    end
+  end
+
+  if not is_nil_or_boolean(options[str_const.require_nbf_claim]) then
+    error(string.format("'%s' validation option is expected to be a boolean.", str_const.require_nbf_claim), 0)
+  end
+
+  if not is_nil_or_boolean(options[str_const.require_exp_claim]) then
+    error(string.format("'%s' validation option is expected to be a boolean.", str_const.require_exp_claim), 0)
+  end
+
+  if options[str_const.lifetime_grace_period] ~= nil or options[str_const.require_nbf_claim] ~= nil or options[str_const.require_exp_claim] ~= nil then
+    if options[str_const.require_nbf_claim] == true then
+      claim_spec[str_const.nbf] = jwt_validators.is_not_before()
+    else
+      claim_spec[str_const.nbf] = jwt_validators.opt_is_not_before()
+    end
+
+    if options[str_const.require_exp_claim] == true then
+      claim_spec[str_const.exp] = jwt_validators.is_not_expired()
+    else
+      claim_spec[str_const.exp] = jwt_validators.opt_is_not_expired()
+    end
+  end
+
+  return claim_spec
+end
+
+local function is_legacy_validation_options(options)
+
+  -- Validation options MUST be a table
+  if type(options) ~= str_const.table then
+    return false
+  end
+
+  -- Validation options MUST have at least one of these, and must ONLY have these
+  local legacy_options = { }
+  legacy_options[str_const.valid_issuers]=1
+  legacy_options[str_const.lifetime_grace_period]=1
+  legacy_options[str_const.require_nbf_claim]=1
+  legacy_options[str_const.require_exp_claim]=1
+
+  local is_legacy = false
+  for k in pairs(options) do
+    if legacy_options[k] ~= nil then
+      is_legacy = true
+    else
+      return false
+    end
+  end
+  return is_legacy
+end
+
+-- Validates the claims for the given (parsed) object
+local function validate_claims(self, jwt_obj, ...)
+  local claim_specs = {...}
+
+  if jwt_obj[str_const.reason] ~= nil then
+    return false
+  end
+
+  -- Encode the current jwt_obj and use it when calling the individual validation functions
+  local jwt_json = cjson_encode(jwt_obj)
+
+  -- Validate all our specs
+  for _, claim_spec in ipairs(claim_specs) do
+    if is_legacy_validation_options(claim_spec) then
+      claim_spec = get_claim_spec_from_legacy_options(self, claim_spec)
+    end
+    for claim, fx in pairs(claim_spec) do
+      if type(fx) ~= str_const.funct then
+        error("Claim spec value must be a function - see jwt-validators.lua for helper functions", 0)
+      end
+
+      local val = claim == str_const.full_obj and cjson_decode(jwt_json) or jwt_obj.payload[claim]
+      local success, ret = pcall(fx, val, claim, jwt_json)
+      if not success then
+        jwt_obj[str_const.reason] = ret.reason or string.gsub(ret, "^.-:%d-: ", "")
+        return false
+      elseif ret == false then
+        jwt_obj[str_const.reason] = string.format("Claim '%s' ('%s') returned failure", claim, val)
+        return false
+      end
+    end
+  end
+
+  -- Everything was good
+  return true
+end
+
+--@function verify jwt object
+--@param secret
+--@param jwt_object
+--@leeway
+--@return verified jwt payload or jwt object with error code
+function _M.verify_jwt_obj(self, secret, jwt_obj, ...)
+  if not jwt_obj.valid then
+    return jwt_obj
+  end
+
+  -- validate any claims that have been passed in
+  if not validate_claims(self, jwt_obj, ...) then
+    return jwt_obj
+  end
+
+  -- if jwe, invoked verify jwe
+  if jwt_obj[str_const.header][str_const.enc] then
+    return verify_jwe_obj(secret, jwt_obj)
+  end
+
+  local alg = jwt_obj[str_const.header][str_const.alg]
+
+  local jwt_str = string_format(str_const.regex_jwt_join_str, jwt_obj.raw_header , jwt_obj.raw_payload , jwt_obj.signature)
+
+
+
+  if self.alg_whitelist ~= nil then
+    if self.alg_whitelist[alg] == nil then
+      return {verified=false, reason="whitelist unsupported alg: " .. alg}
+    end
+  end
+
+  if alg == str_const.HS256 or alg == str_const.HS512 then
+    local success, ret = pcall(_M.sign, self, secret, jwt_obj)
+    if not success then
+      -- syntax check
+      jwt_obj[str_const.reason] = ret[str_const.reason] or str_const.internal_error
+    elseif jwt_str ~= ret then
+      -- signature check
+      jwt_obj[str_const.reason] = "signature mismatch: " .. jwt_obj[str_const.signature]
+    end
+  elseif alg == str_const.RS256 then
+    local cert, err
+    if self.trusted_certs_file ~= nil then
+      local cert_str = extract_certificate(jwt_obj, self.x5u_content_retriever)
+      if not cert_str then
+        return jwt_obj
+      end
+      cert, err = evp.Cert:new(cert_str)
+      if not cert then
+        jwt_obj[str_const.reason] = "Unable to extract signing cert from JWT: " .. err
+        return jwt_obj
+      end
+      -- Try validating against trusted CA's, then a cert passed as secret
+      local trusted, err = cert:verify_trust(self.trusted_certs_file)
+      if not trusted then
+        jwt_obj[str_const.reason] = "Cert used to sign the JWT isn't trusted: " .. err
+        return jwt_obj
+      end
+    elseif secret ~= nil then
+      local err
+      if secret:find("CERTIFICATE") then
+        cert, err = evp.Cert:new(secret)
+      elseif secret:find("PUBLIC KEY") then
+        cert, err = evp.PublicKey:new(secret)
+      end
+      if not cert then
+        jwt_obj[str_const.reason] = "Decode secret is not a valid cert/public key: " .. (err and err or secret)
+        return jwt_obj
+      end
+    else
+      jwt_obj[str_const.reason] = "No trusted certs loaded"
+      return jwt_obj
+    end
+    local verifier, err = evp.RSAVerifier:new(cert)
+    if not verifier then
+      -- Internal error case, should not happen...
+      jwt_obj[str_const.reason] = "Failed to build verifier " .. err
+      return jwt_obj
     end
 
     -- assemble jwt parts
-    local raw_header = get_raw_part("header", jwt_obj)
-    local raw_payload = get_raw_part("payload", jwt_obj)
+    local raw_header = get_raw_part(str_const.header, jwt_obj)
+    local raw_payload = get_raw_part(str_const.payload, jwt_obj)
 
-    local message =raw_header ..  "." ..  raw_payload
+    local message =string_format(str_const.regex_join_msg, raw_header ,  raw_payload)
+    local sig = _M:jwt_decode(jwt_obj[str_const.signature], false)
 
-    -- header alg check
-    local alg = jwt_obj["header"]["alg"]
-    local signature = ""
-    if alg == "HS256" then
-        signature = hmac:new(secret_key, hmac.ALGOS.SHA256):final(message)
-    elseif alg == "HS512" then
-        signature = hmac:new(secret_key, hmac.ALGOS.SHA512):final(message)
-    elseif alg == "RS256" then
-        local signer, err = evp.RSASigner:new(secret_key)
-        if not signer then
-            error({reason="signer error: " .. err})
-        end
-        signature = signer:sign(message, evp.CONST.SHA256_DIGEST)
-    else
-        error({reason="unsupported alg: " .. alg})
+    if not sig then
+      jwt_obj[str_const.reason] = "Wrongly encoded signature"
+      return jwt_obj
     end
-    -- return full jwt string
-    return message .. "." .. _M:jwt_encode(signature)
+
+    local verified, err = verifier:verify(message, sig, evp.CONST.SHA256_DIGEST)
+    if not verified then
+      jwt_obj[str_const.reason] = err
+    end
+  else
+    jwt_obj[str_const.reason] = "Unsupported algorithm " .. alg
+  end
+
+  if not jwt_obj[str_const.reason] then
+    jwt_obj[str_const.verified] = true
+    jwt_obj[str_const.reason] = str_const.everything_awesome
+  end
+  return jwt_obj
+
 end
 
 
-function _M.load_jwt(self, jwt_str)
-    local success, ret = pcall(parse, jwt_str)
-    if not success then
-        return {
-            valid=false,
-            verified=false,
-            reason=ret["reason"] or "invalid jwt string"
-        }
-    end
+function _M.verify(self, secret, jwt_str, ...)
+  local jwt_obj = _M.load_jwt(self, jwt_str, secret)
+  if not jwt_obj.valid then
+    return {verified=false, reason=jwt_obj[str_const.reason]}
+  end
+  return  _M.verify_jwt_obj(self, secret, jwt_obj, ...)
 
-    local jwt_obj = ret
-    jwt_obj["verified"] = false
-    jwt_obj["valid"] = true
-    return jwt_obj
-end
-
-
-function _M.verify_jwt_obj(self, secret, jwt_obj, leeway)
-    local jwt_str = jwt_obj.raw_header ..
-        "." .. jwt_obj.raw_payload ..
-        "." .. jwt_obj.signature
-
-    if not jwt_obj.valid then
-        return jwt_obj
-    end
-    local alg = jwt_obj["header"]["alg"]
-    if self.alg_whitelist ~= nil then
-        if self.alg_whitelist[alg] == nil then
-            return {verified=false, reason="whitelist unsupported alg: " .. alg}
-        end
-    end
-    if alg == "HS256" or alg == "HS512" then
-        local success, ret = pcall(_M.sign, self, secret, jwt_obj)
-        if not success then
-            -- syntax check
-            jwt_obj["reason"] = ret["reason"] or "internal error"
-        elseif jwt_str ~= ret then
-            -- signature check
-            jwt_obj["reason"] = "signature mismatch: " .. jwt_obj["signature"]
-        end
-    elseif alg == "RS256" then
-        local cert
-        if self.trusted_certs_file ~= nil then
-            local err, x5c = jwt_obj['header']['x5c']
-            if not x5c or not x5c[1] then
-                jwt_obj["reason"] = "Unsupported RS256 key model"
-                return jwt_obj
-                -- TODO - Implement jwk and kid based models...
-            end
-    
-            -- TODO Might want to add support for intermediaries that we
-            -- don't have in our trusted chain (items 2... if present)
-            local cert_str = ngx.decode_base64(x5c[1])
-            if not cert_str then
-                jwt_obj["reason"] = "Malformed x5c header"
-                return jwt_obj
-            end
-            cert, err = evp.Cert:new(cert_str)
-            if not cert then
-                jwt_obj["reason"] = "Unable to extract signing cert from JWT: " .. err
-                return jwt_obj
-            end
-            -- Try validating against trusted CA's, then a cert passed as secret
-            local trusted, err = cert:verify_trust(self.trusted_certs_file)
-            if not trusted then
-                jwt_obj["reason"] = "Cert used to sign the JWT isn't trusted: " .. err
-                return jwt_obj
-            end
-        elseif secret ~= nil then
-            local err
-            cert, err = evp.Cert:new(secret)
-            if not cert then
-                jwt_obj["reason"] = "Decode secret is not a valid cert: " .. err
-                return jwt_obj
-            end
-        else
-            jwt_obj["reason"] = "No trusted certs loaded"
-            return jwt_obj
-        end
-        local verifier, err = evp.RSAVerifier:new(cert)
-        if not verifier then
-            -- Internal error case, should not happen...
-            jwt_obj["reason"] = "Failed to build verifier " .. err
-            return jwt_obj
-        end
-
-        -- assemble jwt parts
-        local raw_header = get_raw_part("header", jwt_obj)
-        local raw_payload = get_raw_part("payload", jwt_obj)
-
-        local message =raw_header ..  "." ..  raw_payload
-        local sig = jwt_obj["signature"]:gsub("-", "+"):gsub("_", "/")
-        local verified, err = verifier:verify(message, _M:jwt_decode(sig, false), evp.CONST.SHA256_DIGEST)
-        if not verified then
-            jwt_obj["reason"] = err
-        end
-    else
-        jwt_obj["reason"] = "Unsupported algorithm " .. alg
-    end
-
-    local exp = jwt_obj["payload"]["exp"]
-    local nbf = jwt_obj["payload"]["nbf"]
-
-    if (exp ~= nil or nbf ~= nil ) and not jwt_obj["reason"] then
-        leeway = leeway or 0
-        local now = ngx.now()
-
-        if type(exp) == "number" and exp < (now - leeway) then
-            jwt_obj["reason"] = "jwt token expired at: " ..
-                ngx.http_time(exp)
-        elseif type(nbf) == "number" and nbf > (now + leeway) then
-            jwt_obj["reason"] = "jwt token not valid until: " ..
-                ngx.http_time(nbf)
-        end
-    end
-
-    if not jwt_obj["reason"] then
-        jwt_obj["verified"] = true
-        jwt_obj["reason"] = "everything is awesome~ :p"
-    end
-    return jwt_obj
-end
-
-
-function _M.verify(self, secret, jwt_str, leeway)
-    jwt_obj = _M.load_jwt(self, jwt_str)
-    if not jwt_obj.valid then
-         return {verified=false, reason=jwt_obj["reason"]}
-    end
-
-    return _M.verify_jwt_obj(self, secret, jwt_obj, leeway)
 end
 
 return _M


### PR DESCRIPTION
This basically:
* bumps resty/* libraries to be in sync with those used in EE
* standardizes on 127.0.0.1 in upstreams instead of localhost,
* and the most important one - it removes extra safeguars from loading SECRET_KEY, namely stripping white-space from the key and reading only the first line.

This make it easier to write test-harness because:
* `localhost` entries in upstream definitions cause nginx to connect to http:///[::1]/foo/bar backend, which does not exists, and it also saves some dns query log entries in tests logs
* as the auth.lua code is algo agnostic, we can use RS256 JWTs in tests and thus avoid adding extra code for soon-to-be-deprecated HS256 to the test fixture. 

The open question is whether we should also backport whitelisting algos using ENV var just like we do in EE. Currently, sending RS256 tokens will not work anyway as the dc/os writes a plain-text random string which is a proper key for HS256 but will fail JWT validation if used for RS256 algo.

This change relies on the fact that DC/OS prepares HS256 secret in proper manner, so that extra validation steps in get_stripped_first_line_from_file are not needed anyway. We can make it conditional basing on the JWT algo if necessary/needed.

Comments welcome.
