### PR TITLE
Add metrics endpoint to master nginx.conf

### DIFF
--- a/nginx.master.conf
+++ b/nginx.master.conf
@@ -315,5 +315,18 @@ http {
             include common/proxy-headers.conf;
             proxy_pass http://metrics/;
         }
+
+        location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)/metrics/v0/(?<url>.*)$ {
+            access_by_lua 'auth.validate_jwt_or_exit()';
+            set $agentaddr '';
+            more_clear_input_headers Accept-Encoding;
+            rewrite ^/(slave|agent)/[0-9a-zA-Z-]+/.*$ $url break;
+            rewrite_by_lua_file conf/master/agent.lua;
+
+            include common/server-sent-events.conf;
+            include common/proxy-headers.conf;
+
+            proxy_pass http://$agentaddr:61001/system/v1/metrics/v0/$url$is_args$query_string;
+        }
     }
 }


### PR DESCRIPTION
This PR adds the `/system/v1/agent/<agentid>/metrics/v0/` endpoint to the 
nginx.conf file on master. 

As with the logs endpoint, this is proxied to the appropriate agent.