### PR TITLE
Refactoring agent logging api endpoints

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,7 +109,8 @@ ENV AUTH_ERROR_PAGE_DIR_PATH=${AR_BIN_DIR}/nginx/conf/errorpages
 COPY ./ca.crt /run/dcos/pki/CA/certs/ca.crt
 COPY ./adminrouter.crt /run/dcos/pki/tls/certs/adminrouter.crt
 COPY ./adminrouter.key /run/dcos/pki/tls/private/adminrouter.key
-COPY ./adminrouter-listen.conf /opt/mesosphere/etc/adminrouter-listen.conf
+COPY ./adminrouter-listen-master.conf /opt/mesosphere/etc/adminrouter-listen-master.conf
+COPY ./adminrouter-listen-agent.conf /opt/mesosphere/etc/adminrouter-listen-agent.conf
 COPY ./adminrouter-redirect-http-https.conf /opt/mesosphere/etc/adminrouter-redirect-http-https.conf
 COPY ./adminrouter-upstreams.conf /opt/mesosphere/etc/adminrouter-upstreams.conf
 

--- a/docker/adminrouter-listen-agent.conf
+++ b/docker/adminrouter-listen-agent.conf
@@ -1,0 +1,1 @@
+listen 127.0.0.1:61001 default_server;

--- a/docker/adminrouter-listen-master.conf
+++ b/docker/adminrouter-listen-master.conf
@@ -1,8 +1,8 @@
-listen 80 default_server;
+listen 127.0.0.1:80 default_server;
 
 # We may want to check if the configuration permits only certain TLS encryption
 # schemes. Otherwise it's going to be unused.
-listen 443 ssl default_server;
+listen 127.0.0.1:443 ssl default_server;
 
 # Redirection to 443/TLS is security-mode dependent and as such should be
 # done in integration tests. All tests will be running in plain HTTP. At some

--- a/docker/dnsmasq.conf
+++ b/docker/dnsmasq.conf
@@ -16,9 +16,9 @@
 # these requests from bringing up the link unnecessarily.
 
 # Never forward plain names (without a dot or domain part)
-#domain-needed
+domain-needed
 # Never forward addresses in the non-routed address spaces.
-#bogus-priv
+bogus-priv
 
 # Uncomment these to enable DNSSEC validation and caching:
 # (Requires dnsmasq to be built with DNSSEC option.)
@@ -71,7 +71,7 @@ resolv-file=/etc/resolv.conf.dnsmasq
 
 # Add local-only domains here, queries in these domains are answered
 # from /etc/hosts or DHCP only.
-#local=/localnet/
+local=/mesos/
 
 # Add domains which you want to force to an IP address here.
 # The example below send any host in double-click.net to a local

--- a/docker/hosts.dnsmasq
+++ b/docker/hosts.dnsmasq
@@ -3,10 +3,3 @@
 127.0.0.1 master.mesos
 127.0.0.1 agent.mesos
 127.0.0.1 slave.mesos
-
-# IPv6 - even though it is not used, we still need to define it so that dnsmasq
-# does not try to forward these requests to upstream servers.
-::1 leader.mesos
-::1 master.mesos
-::1 agent.mesos
-::1 slave.mesos

--- a/nginx.agent.conf
+++ b/nginx.agent.conf
@@ -20,7 +20,7 @@ http {
         server_name agent.mesos;
         include common/server.conf;
 
-        listen 61001 default_server;
+        include /opt/mesosphere/etc/adminrouter-listen.conf;
 
         location /system/health/v1 {
             include common/proxy-headers.conf;

--- a/nginx.master.conf
+++ b/nginx.master.conf
@@ -285,35 +285,42 @@ http {
             proxy_pass http://log/;
         }
 
-        location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)/logs/v1/(?<url>.*)$ {
-            access_by_lua 'auth.validate_jwt_or_exit()';
-            set $agentaddr '';
-            more_clear_input_headers Accept-Encoding;
-            rewrite ^/(slave|agent)/[0-9a-zA-Z-]+/.*$ $url break;
-            rewrite_by_lua_file conf/master/agent.lua;
-
-            include common/server-sent-events.conf;
-            include common/proxy-headers.conf;
-
-            proxy_pass http://$agentaddr:61001/system/v1/logs/v1/$url$is_args$query_string;
-        }
-
-        location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>.*)$ {
-            access_by_lua 'auth.validate_jwt_or_exit()';
-            set $agentaddr '';
-            more_clear_input_headers Accept-Encoding;
-            rewrite ^/(slave|agent)/[0-9a-zA-Z-]+/.*$ $url break;
-            rewrite_by_lua_file conf/master/agent.lua;
-
-            include common/proxy-headers.conf;
-
-            proxy_pass http://$agentaddr:61001/system/v1/$url$is_args$query_string;
-        }
-
         location /system/v1/metrics/ {
             access_by_lua 'auth.validate_jwt_or_exit()';
+
             include common/proxy-headers.conf;
             proxy_pass http://metrics/;
         }
+
+		# Ordering is important for these two endpoints!!!
+        location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<type>(/logs/v1))(?<url>.*)$ {
+            access_by_lua 'auth.validate_jwt_or_exit()';
+
+            set $agentaddr '';
+            rewrite_by_lua_file conf/master/agent.lua;
+
+            rewrite ^/agent/[0-9a-zA-Z-]+(.*)$ $1 break;
+
+            more_clear_input_headers Accept-Encoding;
+            include common/server-sent-events.conf;
+            include common/proxy-headers.conf;
+
+            proxy_pass http://$agentaddr:61001/system/v1$type$url$is_args$query_string;
+		}
+
+        location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>.*)$ {
+            access_by_lua 'auth.validate_jwt_or_exit()';
+
+            set $agentaddr '';
+            rewrite_by_lua_file conf/master/agent.lua;
+
+            rewrite ^/agent/[0-9a-zA-Z-]+(.*)$ $1 break;
+
+            more_clear_input_headers Accept-Encoding;
+            include common/proxy-headers.conf;
+
+            proxy_pass http://$agentaddr:61001/system/v1$url$is_args$query_string;
+        }
+		# ...ordering ends
     }
 }

--- a/test-harness/modules/mocker/common.py
+++ b/test-harness/modules/mocker/common.py
@@ -56,6 +56,12 @@ class MockerBase():
         res.append(MesosEndpoint(ip='127.0.0.1', port=5050))
         # marathon
         res.append(MarathonEndpoint(ip='127.0.0.1', port=8080))
+        # slave1
+        res.append(ReflectingTcpIpEndpoint(ip='127.0.0.2', port=15001))
+        # slave2
+        res.append(ReflectingTcpIpEndpoint(ip='127.0.0.3', port=15002))
+        # slave3
+        res.append(ReflectingTcpIpEndpoint(ip='127.0.0.4', port=15003))
         # TODO - other endpoints go here...
 
         return res

--- a/test-harness/modules/mocker/common.py
+++ b/test-harness/modules/mocker/common.py
@@ -62,6 +62,10 @@ class MockerBase():
         res.append(ReflectingTcpIpEndpoint(ip='127.0.0.3', port=15002))
         # slave3
         res.append(ReflectingTcpIpEndpoint(ip='127.0.0.4', port=15003))
+        # Slave AR 1
+        res.append(ReflectingTcpIpEndpoint(ip='127.0.0.2', port=61001))
+        # Slave AR 2
+        res.append(ReflectingTcpIpEndpoint(ip='127.0.0.3', port=61001))
         # TODO - other endpoints go here...
 
         return res

--- a/test-harness/modules/mocker/endpoints/mesos.py
+++ b/test-harness/modules/mocker/endpoints/mesos.py
@@ -3,6 +3,7 @@
 
 """Mesos mock endpoint"""
 
+import copy
 import logging
 
 from exceptions import EndpointException
@@ -13,6 +14,230 @@ from mocker.endpoints.recording import (
 
 # pylint: disable=C0103
 log = logging.getLogger(__name__)
+
+INITIAL_STATEJSON = {
+    "cluster": "prozlach-qzpz04t",
+    "frameworks": [
+        {
+            "TASK_ERROR": 0,
+            "TASK_FAILED": 0,
+            "TASK_FINISHED": 0,
+            "TASK_KILLED": 0,
+            "TASK_KILLING": 0,
+            "TASK_LOST": 0,
+            "TASK_RUNNING": 0,
+            "TASK_STAGING": 0,
+            "TASK_STARTING": 0,
+            "active": True,
+            "capabilities": [],
+            "hostname": "10.0.5.35",
+            "id": "de1baf83-c36c-4d23-9cb0-f89f596cd6ab-0001",
+            "name": "metronome",
+            "offered_resources": {
+                "cpus": 0.0,
+                "disk": 0.0,
+                "gpus": 0.0,
+                "mem": 0.0
+            },
+            "pid": "scheduler-f43b84ec-16c3-455c-94df-158885642b88@10.0.5.35:36857",
+            "slave_ids": [],
+            "used_resources": {
+                "cpus": 0.0,
+                "disk": 0.0,
+                "gpus": 0.0,
+                "mem": 0.0
+            },
+            "webui_url": "http://10.0.5.35:9090"
+        },
+        {
+            "TASK_ERROR": 0,
+            "TASK_FAILED": 0,
+            "TASK_FINISHED": 0,
+            "TASK_KILLED": 0,
+            "TASK_KILLING": 0,
+            "TASK_LOST": 0,
+            "TASK_RUNNING": 0,
+            "TASK_STAGING": 0,
+            "TASK_STARTING": 0,
+            "active": True,
+            "capabilities": [
+                "TASK_KILLING_STATE",
+                "PARTITION_AWARE"
+            ],
+            "hostname": "10.0.5.35",
+            "id": "de1baf83-c36c-4d23-9cb0-f89f596cd6ab-0000",
+            "name": "marathon",
+            "offered_resources": {
+                "cpus": 0.0,
+                "disk": 0.0,
+                "gpus": 0.0,
+                "mem": 0.0
+            },
+            "pid": "scheduler-43d78acd-8c22-4a42-82e5-43c64407038c@10.0.5.35:38457",
+            "slave_ids": [],
+            "used_resources": {
+                "cpus": 0.0,
+                "disk": 0.0,
+                "gpus": 0.0,
+                "mem": 0.0
+            },
+            "webui_url": "https://10.0.5.35:8443"
+        }
+    ],
+    "hostname": "10.0.5.35",
+    "slaves": [
+        {
+            "TASK_ERROR": 0,
+            "TASK_FAILED": 0,
+            "TASK_FINISHED": 0,
+            "TASK_KILLED": 0,
+            "TASK_KILLING": 0,
+            "TASK_LOST": 0,
+            "TASK_RUNNING": 0,
+            "TASK_STAGING": 0,
+            "TASK_STARTING": 0,
+            "active": True,
+            "attributes": {},
+            "framework_ids": [],
+            "hostname": "127.0.0.2",
+            "id": "de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1",
+            "offered_resources": {
+                "cpus": 0.0,
+                "disk": 0.0,
+                "gpus": 0.0,
+                "mem": 0.0
+            },
+            "pid": "slave(1)@127.0.0.2:15001",
+            "registered_time": 1480619701.48294,
+            "reserved_resources": {},
+            "resources": {
+                "cpus": 4.0,
+                "disk": 35577.0,
+                "gpus": 0.0,
+                "mem": 14018.0,
+                "ports": ("[1025-2180, 2182-3887, 3889-5049,"
+                          "5052-8079, 8082-8180, 8182-32000]")
+            },
+            "unreserved_resources": {
+                "cpus": 4.0,
+                "disk": 35577.0,
+                "gpus": 0.0,
+                "mem": 14018.0,
+                "ports": ("[1025-2180, 2182-3887, 3889-5049,"
+                          "5052-8079, 8082-8180, 8182-32000]")
+            },
+            "used_resources": {
+                "cpus": 0.0,
+                "disk": 0.0,
+                "gpus": 0.0,
+                "mem": 0.0
+            },
+            "version": "1.2.0"
+        },
+        {
+            "TASK_ERROR": 0,
+            "TASK_FAILED": 0,
+            "TASK_FINISHED": 0,
+            "TASK_KILLED": 0,
+            "TASK_KILLING": 0,
+            "TASK_LOST": 0,
+            "TASK_RUNNING": 0,
+            "TASK_STAGING": 0,
+            "TASK_STARTING": 0,
+            "active": True,
+            "attributes": {
+                "public_ip": "true"
+            },
+            "framework_ids": [],
+            "hostname": "127.0.0.3",
+            "id": "de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0",
+            "offered_resources": {
+                "cpus": 0.0,
+                "disk": 0.0,
+                "gpus": 0.0,
+                "mem": 0.0
+            },
+            "pid": "slave(1)@127.0.0.3:15002",
+            "registered_time": 1480619699.20796,
+            "reserved_resources": {
+                "slave_public": {
+                    "cpus": 4.0,
+                    "disk": 35577.0,
+                    "gpus": 0.0,
+                    "mem": 14018.0,
+                    "ports": "[1-21, 23-5050, 5052-32000]"
+                }
+            },
+            "resources": {
+                "cpus": 4.0,
+                "disk": 35577.0,
+                "gpus": 0.0,
+                "mem": 14018.0,
+                "ports": "[1-21, 23-5050, 5052-32000]"
+            },
+            "unreserved_resources": {
+                "cpus": 0.0,
+                "disk": 0.0,
+                "gpus": 0.0,
+                "mem": 0.0
+            },
+            "used_resources": {
+                "cpus": 0.0,
+                "disk": 0.0,
+                "gpus": 0.0,
+                "mem": 0.0
+            },
+            "version": "1.2.0"
+        }
+    ]
+}
+
+EXTRA_SLAVE_DICT = {
+    "id": "8ad5a85c-c14b-4cca-a089-b9dc006e7286-S2",
+    "pid": "slave(1)@127.0.0.4:15003",
+    "hostname": "127.0.0.4",
+    "registered_time": 1484580645.5393,
+    "resources": {
+        "disk": 35577.0,
+        "mem": 14018.0,
+        "gpus": 0.0,
+        "cpus": 4.0,
+        "ports": "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+    },
+    "used_resources": {
+        "disk": 0.0,
+        "mem": 0.0,
+        "gpus": 0.0,
+        "cpus": 0.0
+    },
+    "offered_resources": {
+        "disk": 0.0,
+        "mem": 0.0,
+        "gpus": 0.0,
+        "cpus": 0.0
+    },
+    "reserved_resources": {},
+    "unreserved_resources": {
+        "disk": 35577.0,
+        "mem": 14018.0,
+        "gpus": 0.0,
+        "cpus": 4.0,
+        "ports": "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+    },
+    "attributes": {},
+    "active": True,
+    "version": "1.2.0",
+    "TASK_STAGING": 0,
+    "TASK_STARTING": 0,
+    "TASK_RUNNING": 0,
+    "TASK_KILLING": 0,
+    "TASK_FINISHED": 0,
+    "TASK_KILLED": 0,
+    "TASK_FAILED": 0,
+    "TASK_LOST": 0,
+    "TASK_ERROR": 0,
+    "framework_ids": []
+}
 
 
 # pylint: disable=R0903
@@ -33,183 +258,10 @@ class MesosHTTPRequestHandler(RecordingHTTPRequestHandler):
             blob = msg.encode('utf-8')
             raise EndpointException(code=500, reason=blob)
 
-        res = {"cluster": "prozlach-qzpz04t",
-               "frameworks": [
-                   {
-                       "TASK_ERROR": 0,
-                       "TASK_FAILED": 0,
-                       "TASK_FINISHED": 0,
-                       "TASK_KILLED": 0,
-                       "TASK_KILLING": 0,
-                       "TASK_LOST": 0,
-                       "TASK_RUNNING": 0,
-                       "TASK_STAGING": 0,
-                       "TASK_STARTING": 0,
-                       "active": True,
-                       "capabilities": [],
-                       "hostname": "10.0.5.35",
-                       "id": "de1baf83-c36c-4d23-9cb0-f89f596cd6ab-0001",
-                       "name": "metronome",
-                       "offered_resources": {
-                           "cpus": 0.0,
-                           "disk": 0.0,
-                           "gpus": 0.0,
-                           "mem": 0.0
-                       },
-                       "pid": "scheduler-f43b84ec-16c3-455c-94df-158885642b88@10.0.5.35:36857",
-                       "slave_ids": [],
-                       "used_resources": {
-                           "cpus": 0.0,
-                           "disk": 0.0,
-                           "gpus": 0.0,
-                           "mem": 0.0
-                       },
-                       "webui_url": "http://10.0.5.35:9090"
-                   },
-                   {
-                       "TASK_ERROR": 0,
-                       "TASK_FAILED": 0,
-                       "TASK_FINISHED": 0,
-                       "TASK_KILLED": 0,
-                       "TASK_KILLING": 0,
-                       "TASK_LOST": 0,
-                       "TASK_RUNNING": 0,
-                       "TASK_STAGING": 0,
-                       "TASK_STARTING": 0,
-                       "active": True,
-                       "capabilities": [
-                           "TASK_KILLING_STATE",
-                           "PARTITION_AWARE"
-                       ],
-                       "hostname": "10.0.5.35",
-                       "id": "de1baf83-c36c-4d23-9cb0-f89f596cd6ab-0000",
-                       "name": "marathon",
-                       "offered_resources": {
-                           "cpus": 0.0,
-                           "disk": 0.0,
-                           "gpus": 0.0,
-                           "mem": 0.0
-                       },
-                       "pid": "scheduler-43d78acd-8c22-4a42-82e5-43c64407038c@10.0.5.35:38457",
-                       "slave_ids": [],
-                       "used_resources": {
-                           "cpus": 0.0,
-                           "disk": 0.0,
-                           "gpus": 0.0,
-                           "mem": 0.0
-                       },
-                       "webui_url": "https://10.0.5.35:8443"
-                   }
-               ],
-               "hostname": "10.0.5.35",
-               "slaves": [
-                   {
-                       "TASK_ERROR": 0,
-                       "TASK_FAILED": 0,
-                       "TASK_FINISHED": 0,
-                       "TASK_KILLED": 0,
-                       "TASK_KILLING": 0,
-                       "TASK_LOST": 0,
-                       "TASK_RUNNING": 0,
-                       "TASK_STAGING": 0,
-                       "TASK_STARTING": 0,
-                       "active": True,
-                       "attributes": {},
-                       "framework_ids": [],
-                       "hostname": "10.0.1.10",
-                       "id": "de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1",
-                       "offered_resources": {
-                           "cpus": 0.0,
-                           "disk": 0.0,
-                           "gpus": 0.0,
-                           "mem": 0.0
-                       },
-                       "pid": "slave(1)@10.0.1.10:5051",
-                       "registered_time": 1480619701.48294,
-                       "reserved_resources": {},
-                       "resources": {
-                           "cpus": 4.0,
-                           "disk": 35577.0,
-                           "gpus": 0.0,
-                           "mem": 14018.0,
-                           "ports": ("[1025-2180, 2182-3887, 3889-5049,"
-                                     "5052-8079, 8082-8180, 8182-32000]")
-                       },
-                       "unreserved_resources": {
-                           "cpus": 4.0,
-                           "disk": 35577.0,
-                           "gpus": 0.0,
-                           "mem": 14018.0,
-                           "ports": ("[1025-2180, 2182-3887, 3889-5049,"
-                                     "5052-8079, 8082-8180, 8182-32000]")
-                       },
-                       "used_resources": {
-                           "cpus": 0.0,
-                           "disk": 0.0,
-                           "gpus": 0.0,
-                           "mem": 0.0
-                       },
-                       "version": "1.2.0"
-                   },
-                   {
-                       "TASK_ERROR": 0,
-                       "TASK_FAILED": 0,
-                       "TASK_FINISHED": 0,
-                       "TASK_KILLED": 0,
-                       "TASK_KILLING": 0,
-                       "TASK_LOST": 0,
-                       "TASK_RUNNING": 0,
-                       "TASK_STAGING": 0,
-                       "TASK_STARTING": 0,
-                       "active": True,
-                       "attributes": {
-                           "public_ip": "true"
-                       },
-                       "framework_ids": [],
-                       "hostname": "10.0.4.214",
-                       "id": "de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0",
-                       "offered_resources": {
-                           "cpus": 0.0,
-                           "disk": 0.0,
-                           "gpus": 0.0,
-                           "mem": 0.0
-                       },
-                       "pid": "slave(1)@10.0.4.214:5051",
-                       "registered_time": 1480619699.20796,
-                       "reserved_resources": {
-                           "slave_public": {
-                               "cpus": 4.0,
-                               "disk": 35577.0,
-                               "gpus": 0.0,
-                               "mem": 14018.0,
-                               "ports": "[1-21, 23-5050, 5052-32000]"
-                           }
-                       },
-                       "resources": {
-                           "cpus": 4.0,
-                           "disk": 35577.0,
-                           "gpus": 0.0,
-                           "mem": 14018.0,
-                           "ports": "[1-21, 23-5050, 5052-32000]"
-                       },
-                       "unreserved_resources": {
-                           "cpus": 0.0,
-                           "disk": 0.0,
-                           "gpus": 0.0,
-                           "mem": 0.0
-                       },
-                       "used_resources": {
-                           "cpus": 0.0,
-                           "disk": 0.0,
-                           "gpus": 0.0,
-                           "mem": 0.0
-                       },
-                       "version": "1.2.0"
-                   }
-                   ]
-               }
+        ctx = self.server.context
 
-        blob = self._convert_data_to_blob(res)
+        with ctx.lock:
+            blob = self._convert_data_to_blob(ctx.data['endpoint-content'])
 
         return blob
 
@@ -219,3 +271,14 @@ class MesosEndpoint(RecordingTcpIpEndpoint):
     """An endpoint that mimics DC/OS leader.mesos Mesos"""
     def __init__(self, port, ip=''):
         super().__init__(port, ip, MesosHTTPRequestHandler)
+        self._context.data["endpoint-content"] = copy.deepcopy(INITIAL_STATEJSON)
+
+    def reset(self, *_):
+        """Reset the endpoint to the default/initial state."""
+        with self._context.lock:
+            super().reset()
+            self._context.data["endpoint-content"] = copy.deepcopy(INITIAL_STATEJSON)
+
+    def enable_extra_slave(self, *_):
+        with self._context.lock:
+            self._context.data["endpoint-content"]["slaves"].append(EXTRA_SLAVE_DICT)

--- a/test-harness/modules/util.py
+++ b/test-harness/modules/util.py
@@ -10,6 +10,7 @@
 
 import code
 import logging
+import os
 import pyroute2
 import signal
 import time
@@ -243,3 +244,22 @@ def setup_thread_debugger():
         i.interact(message)
 
     signal.signal(signal.SIGUSR1, debug)  # Register handler
+
+def ar_listen_link_setup(role):
+    assert role in ['master', 'agent']
+
+    src_path = "/opt/mesosphere/etc/adminrouter-listen.conf"
+    dst_path = "adminrouter-listen-{}.conf".format(role)
+
+    if os.path.exists(src_path):
+        assert os.path.islink(src_path)
+
+        cur_dst_path = os.readlink(src_path)
+
+        if cur_dst_path != dst_path:
+            os.unlink(src_path)
+            os.symlink(dst_path, src_path)
+
+        return
+
+    os.symlink(dst_path, src_path)

--- a/test-harness/tests/conftest.py
+++ b/test-harness/tests/conftest.py
@@ -46,7 +46,7 @@ def repo_is_ee():
 
 
 @pytest.fixture(scope='session')
-def mocker_s(repo_is_ee, syslog_mock):
+def mocker_s(repo_is_ee, syslog_mock, extra_lo_ips):
     """Provide a gc-ed mocker instance suitable for the repository flavour"""
     if repo_is_ee:
         from mocker.ee import Mocker
@@ -114,6 +114,19 @@ def dns_mock(log_catcher, navstar_ips, resolvconf_fixup):
 def navstar_ips():
     """Setup IPs that help dns_mock mimic navstar"""
     ips = ['198.51.100.1', '198.51.100.2', '198.51.100.3']
+
+    for ip in ips:
+        add_lo_ipaddr(ip, 32)
+
+    yield
+
+    for ip in ips:
+        del_lo_ipaddr(ip, 32)
+
+
+@pytest.fixture(scope='session')
+def extra_lo_ips():
+    ips = ['127.0.0.2', '127.0.0.3']
 
     for ip in ips:
         add_lo_ipaddr(ip, 32)

--- a/test-harness/tests/conftest.py
+++ b/test-harness/tests/conftest.py
@@ -13,7 +13,7 @@ from runner.common import (
     SyslogMock,
     )
 from mocker.jwt import generate_rs256_jwt, generate_hs256_jwt
-from util import add_lo_ipaddr, del_lo_ipaddr
+from util import add_lo_ipaddr, del_lo_ipaddr, ar_listen_link_setup
 
 
 @pytest.fixture()
@@ -173,8 +173,13 @@ def nginx_class(repo_is_ee, dns_mock, log_catcher, syslog_mock, mocker_s):
     else:
         from runner.open import Nginx
 
-    def f(*args, **kwargs):
-        return Nginx(*args, log_catcher=log_catcher, **kwargs)
+    def f(*args, role=None, **kwargs):
+        # We cannot define it as a fixture due to the fact that nginx_class is
+        # used both in other fixtures and in tests directly. Liten link setup
+        # fixture would have to be pulled in every time nginx_class is used
+        # on its own.
+        ar_listen_link_setup(role)
+        return Nginx(*args, role=role, log_catcher=log_catcher, **kwargs)
 
     return f
 

--- a/test-harness/tests/open/test_master.py
+++ b/test-harness/tests/open/test_master.py
@@ -2,6 +2,7 @@
 # Copyright (C) Mesosphere, Inc. See LICENSE file for details.
 
 import logging
+import pytest
 import requests
 
 from mocker.endpoints.open.iam import IamEndpoint
@@ -28,6 +29,38 @@ class TestExhibitorEndpointOpen():
         generic_valid_user_is_permited_test(master_ar_process,
                                             valid_user_header,
                                             '/exhibitor/some/path')
+
+
+class TestOpenSystemLoggingAgentEndpoint():
+    @pytest.mark.parametrize("path", [
+        (""),
+        ("/logs/v1"),
+        ("/metrics/v0"),
+    ])
+    def test_if_unknown_user_is_forbidden_access(self,
+                                                 master_ar_process,
+                                                 invalid_user_header,
+                                                 path):
+        path_fmt = '/system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1{}/foo/bar'
+        generic_unknown_user_is_forbidden_test(master_ar_process,
+                                               invalid_user_header,
+                                               path_fmt.format(path),
+                                               )
+
+    @pytest.mark.parametrize("path", [
+        (""),
+        ("/logs/v1"),
+        ("/metrics/v0"),
+    ])
+    def test_if_valid_user_is_permitted_access(self,
+                                               master_ar_process,
+                                               valid_user_header,
+                                               path):
+        path_fmt = '/system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1{}/foo/bar'
+        generic_valid_user_is_permited_test(master_ar_process,
+                                            valid_user_header,
+                                            path_fmt.format(path),
+                                            )
 
 
 class TestAuthenticationOpen():


### PR DESCRIPTION
This PR:
* introduces changes to how Agent's listen address is configured so that it's possible to run agent AR instances in the test harness
* it refactors logging API endpoints so that:
  ** fixes bug with some of the requests ending with `//` in the URL
  ** cleanups the rewrite rules
* various test-harness fixes that make testing things mentioned above possible.

Changes in DC/OS *must* follow.

