### PR TITLE
DCOS-13466 Early cache population issue

### DIFF
--- a/test-harness/tests/test_cache.py
+++ b/test-harness/tests/test_cache.py
@@ -1,6 +1,7 @@
 # Copyright (C) Mesosphere, Inc. See LICENSE file for details.
 
 import logging
+import pytest
 import requests
 import time
 
@@ -637,6 +638,60 @@ class TestCache():
 
             # Verify that the cache is OK now
             ping_mesos_agent(ar, valid_user_header)
+
+    def test_if_early_boot_stage_is_not_sensitive_to_failures(
+            self, nginx_class, valid_user_header, mocker, log_catcher):
+        # The idea here is to make Backend so slow, that AR is unable to
+        # update cache on first request. AR should then switch to fail-fast
+        # behaviour and wait for timers to update the backend when it recovers.
+
+        # This test asserts that in the case where a request is blocked,
+        # waiting for a cache update, and that update fails, then all new
+        # requests instantly fail with 503. Requests already queued will time
+        # out just the same way the first one did.
+
+        refresh_lock_timeout = 10
+        backend_request_timeout = 5
+
+        ar = nginx_class(cache_first_poll_delay=1,
+                         cache_poll_period=3,
+                         cache_expiration=2,
+                         cache_max_age_soft_limit=1200,
+                         cache_max_age_hard_limit=1800,
+                         cache_backend_request_timeout=backend_request_timeout,
+                         cache_refresh_lock_timeout=refresh_lock_timeout,
+                         )
+        agent_id = 'de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1'
+        url = ar.make_url_from_path('/agent/{}/blah/blah'.format(agent_id))
+        v = Vegeta(log_catcher, target=url, jwt=valid_user_header, rate=3)
+
+        # Make mesos slooowwwww.....
+        # It mus respond slower than backend_request_timeout
+        mocker.send_command(endpoint_id='http://127.0.0.2:5050',
+                            func_name='always_stall',
+                            aux_data=backend_request_timeout * 1.5)
+
+        with GuardedSubprocess(ar):
+            with GuardedSubprocess(v):
+                time.sleep(1)  # let it warm-up!
+
+                # Vegeta by this time should have already clogged AR
+
+                # Expect request timeout due to the cache lock holding the
+                # requests back
+                with pytest.raises(requests.exceptions.ReadTimeout):
+                    ping_mesos_agent(ar,
+                                     valid_user_header,
+                                     timeout=(10.0, backend_request_timeout * 1.5))
+
+                # Requests from now on should be failing fast
+                try:
+                    ping_mesos_agent(ar,
+                                     valid_user_header,
+                                     timeout=1,
+                                     expect_status=503)
+                except requests.exceptions.ReadTimeout:
+                    assert False, "AR does not fail-fast request after early-boot stage"
 
     def test_if_early_boot_stage_can_recover_from_a_bit_slow_backend(
             self, nginx_class, valid_user_header, mocker, log_catcher):


### PR DESCRIPTION
In the current setup, during the very early stage of AR start (<0,2> seconds timeframe), the cache is still empty as the first timer-triggered update has not run yet. If a request hits AR, cache update is forced to happen independently of timer-based one. This refresh is a blocking one (request waits while the cache is updated), and the timeout is set to 20 seconds - https://github.com/dcos/adminrouter/blob/master/master/mesosstatecache.lua#L233.

In theory, because of this timeout, I think it's possible to Denial-Of-Service Adminrouter in a sufficiently big cluster during this very early stage with lots of requests for i.e. `/service` endpoint. These requests will block if for example Mesos is stuck and does not respond promptly. It also does not fit our new architecture (`cache_max_age_soft_limit`, `cache_max_age_hard_limit` and friends), as during normal AR operation we reply with 500-something if Mesos decides to take it slow and requests can no longer trigger cache refresh on their own if there is a problem with Mesos/Marathon backend. So the early stage algorithm is inconsistent compared to normal error handling/there are different policies for early stage and steady stage operation.

The DOS situation can happen during both early DC/OS boot as well after AR restart.

My proposal is to try to queue requests in the early stage just like we do now, but after the first request failing, we fall back to timers and 5XX all the requests till timer-based cache refresh succeeds. This is a change compared to our current behaviour, and as such, I think it requires wider consensus.

This PR is based against https://github.com/dcos/adminrouter/pull/37, the change itself is just last two commits.