### PR TITLE
Bugfixes.

### DIFF
--- a/master/service.lua
+++ b/master/service.lua
@@ -52,7 +52,3 @@ for _, framework in ipairs(state["frameworks"]) do
     end
   end
 end
-
-ngx.status = ngx.HTTP_NOT_FOUND
-ngx.say("404 Not Found: service `" .. ngx.var.serviceid .. "` unknown")
-return ngx.exit(ngx.HTTP_NOT_FOUND)

--- a/test-harness/modules/mocker/common.py
+++ b/test-harness/modules/mocker/common.py
@@ -69,7 +69,9 @@ class MockerBase():
         res.append(ReflectingTcpIpEndpoint(ip='127.0.0.2', port=61001))
         # Slave AR 2
         res.append(ReflectingTcpIpEndpoint(ip='127.0.0.3', port=61001))
-        # task-nginx
+        # task /nginx-alwaysthere
+        res.append(ReflectingTcpIpEndpoint(ip='127.0.0.1', port=16000))
+        # task /nginx-enabled
         res.append(ReflectingTcpIpEndpoint(ip='127.0.0.1', port=16001))
         # general purpose reflectors, used i.e. for Marathon leader testing
         res.append(ReflectingTcpIpEndpoint(ip='127.0.0.2', port=80))

--- a/test-harness/modules/mocker/endpoints/marathon.py
+++ b/test-harness/modules/mocker/endpoints/marathon.py
@@ -13,8 +13,8 @@ from mocker.endpoints.recording import (
 # pylint: disable=C0103
 log = logging.getLogger(__name__)
 
-NGINX_TASK = {
-    "id": "/nginx",
+NGINX_TASK_ALWAYSTHERE = {
+    "id": "/nginx-alwaysthere",
     "cmd": ("cd /opt/bitnami/nginx && harpoon initialize nginx && "
             "rm -rf /opt/bitnami/nginx/html && ln -s "
             "/mnt/mesos/sandbox/hello-nginx-master/ /opt/bitnami/nginx/html "
@@ -96,7 +96,162 @@ NGINX_TASK = {
         "DCOS_PACKAGE_SOURCE": "https://universe.mesosphere.com/repo",
         "DCOS_PACKAGE_METADATA": "blah, blah, bleh",
         "DCOS_PACKAGE_REGISTRY_VERSION": "2.0",
-        "DCOS_SERVICE_NAME": "nginx",
+        "DCOS_SERVICE_NAME": "nginx-alwaysthere",
+        "DCOS_SERVICE_PORT_INDEX": "0",
+        "DCOS_PACKAGE_VERSION": "1.10.2",
+        "DCOS_PACKAGE_NAME": "nginx",
+        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+    },
+    "ipAddress": None,
+    "version": "2017-01-16T15:48:18.007Z",
+    "residency": None,
+    "secrets": {},
+    "taskKillGracePeriodSeconds": None,
+    "unreachableStrategy": {
+        "inactiveAfterSeconds": 900,
+        "expungeAfterSeconds": 604800
+    },
+    "killSelection": "YOUNGEST_FIRST",
+    "acceptedResourceRoles": [
+        "*"
+    ],
+    "ports": [
+        16000,
+    ],
+    "portDefinitions": [
+        {
+            "port": 16000,
+            "protocol": "tcp",
+            "labels": {}
+        },
+    ],
+    "requirePorts": False,
+    "versionInfo": {
+        "lastScalingAt": "2017-01-16T15:48:18.007Z",
+        "lastConfigChangeAt": "2017-01-16T15:48:18.007Z"
+    },
+    "tasksStaged": 0,
+    "tasksRunning": 1,
+    "tasksHealthy": 1,
+    "tasksUnhealthy": 0,
+    "deployments": [],
+    "tasks": [
+        {
+            "ipAddresses": [
+                {
+                    "ipAddress": "127.0.0.1",
+                    "protocol": "IPv4"
+                }
+            ],
+            "stagedAt": "2017-01-16T15:48:18.463Z",
+            "state": "TASK_RUNNING",
+            "ports": [
+                16000,
+            ],
+            "startedAt": "2017-01-16T15:48:42.061Z",
+            "version": "2017-01-16T15:48:18.007Z",
+            "id": "nginx.333d80f4-dc03-11e6-b993-e248be6c2f96",
+            "appId": "/nginx-alwaysthere",
+            "slaveId": "8ad5a85c-c14b-4cca-a089-b9dc006e7286-S0",
+            "host": "127.0.0.1",
+            "healthCheckResults": [
+                {
+                    "alive": True,
+                    "consecutiveFailures": 0,
+                    "firstSuccess": "2017-01-16T15:48:59.141Z",
+                    "lastFailure": None,
+                    "lastSuccess": "2017-01-16T15:48:59.141Z",
+                    "lastFailureCause": None,
+                    "instanceId": "nginx.marathon-333d80f4-dc03-11e6-b993-e248be6c2f96"
+                }
+            ]
+        }
+    ]
+}
+NGINX_TASK_ENABLED = {
+    "id": "/nginx-enabled",
+    "cmd": ("cd /opt/bitnami/nginx && harpoon initialize nginx && "
+            "rm -rf /opt/bitnami/nginx/html && ln -s "
+            "/mnt/mesos/sandbox/hello-nginx-master/ /opt/bitnami/nginx/html "
+            "&& harpoon start --foreground nginx"),
+    "args": None,
+    "user": None,
+    "env": {},
+    "instances": 1,
+    "cpus": 1,
+    "mem": 1024,
+    "disk": 0,
+    "gpus": 0,
+    "executor": "",
+    "constraints": [],
+    "uris": [
+        "https://github.com/mesosphere/hello-nginx/archive/master.zip"
+    ],
+    "fetch": [
+        {
+            "uri": "https://github.com/mesosphere/hello-nginx/archive/master.zip",
+            "extract": True,
+            "executable": False,
+            "cache": False
+        }
+    ],
+    "storeUrls": [],
+    "backoffSeconds": 1,
+    "backoffFactor": 1.15,
+    "maxLaunchDelaySeconds": 3600,
+    "container": {
+        "type": "DOCKER",
+        "volumes": [],
+        "docker": {
+            "image": "bitnami/nginx:1.10.2-r0",
+            "network": "BRIDGE",
+            "portMappings": [
+                {
+                    "containerPort": 80,
+                    "hostPort": 0,
+                    "servicePort": 10000,
+                    "protocol": "tcp",
+                    "labels": {}
+                },
+                {
+                    "containerPort": 443,
+                    "hostPort": 0,
+                    "servicePort": 10001,
+                    "protocol": "tcp",
+                    "labels": {}
+                }
+            ],
+            "privileged": False,
+            "parameters": [],
+            "forcePullImage": False
+        }
+    },
+    "healthChecks": [
+        {
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "delaySeconds": 15,
+            "command": {
+                "value": "harpoon status nginx | grep -q 'com.bitnami.nginx is running'"
+            },
+            "protocol": "COMMAND"
+        }
+    ],
+    "readinessChecks": [],
+    "dependencies": [],
+    "upgradeStrategy": {
+        "minimumHealthCapacity": 1,
+        "maximumOverCapacity": 1
+    },
+    "labels": {
+        "DCOS_PACKAGE_RELEASE": "5",
+        "DCOS_SERVICE_SCHEME": "http",
+        "DCOS_PACKAGE_SOURCE": "https://universe.mesosphere.com/repo",
+        "DCOS_PACKAGE_METADATA": "blah, blah, bleh",
+        "DCOS_PACKAGE_REGISTRY_VERSION": "2.0",
+        "DCOS_SERVICE_NAME": "nginx-enabled",
         "DCOS_SERVICE_PORT_INDEX": "0",
         "DCOS_PACKAGE_VERSION": "1.10.2",
         "DCOS_PACKAGE_NAME": "nginx",
@@ -151,7 +306,7 @@ NGINX_TASK = {
             "startedAt": "2017-01-16T15:48:42.061Z",
             "version": "2017-01-16T15:48:18.007Z",
             "id": "nginx.333d80f4-dc03-11e6-b993-e248be6c2f96",
-            "appId": "/nginx",
+            "appId": "/nginx-enabled",
             "slaveId": "8ad5a85c-c14b-4cca-a089-b9dc006e7286-S0",
             "host": "127.0.0.1",
             "healthCheckResults": [
@@ -216,14 +371,14 @@ class MarathonEndpoint(RecordingTcpIpEndpoint):
     """An endpoint that mimics DC/OS root Marathon"""
     def __init__(self, port, ip=''):
         super().__init__(port, ip, MarathonHTTPRequestHandler)
-        self._context.data["endpoint-content"] = {"apps": []}
+        self._context.data["endpoint-content"] = {"apps": [NGINX_TASK_ALWAYSTHERE, ]}
         self._context.data["leader-content"] = {"leader": "127.0.0.2:80"}
 
     def reset(self, *_):
         """Reset the endpoint to the default/initial state."""
         with self._context.lock:
             super().reset()
-            self._context.data["endpoint-content"] = {"apps": []}
+            self._context.data["endpoint-content"] = {"apps": [NGINX_TASK_ALWAYSTHERE, ]}
             self._context.data["leader-content"] = {"leader": "127.0.0.2:80"}
 
     def enable_nginx_task(self, *_):
@@ -231,7 +386,7 @@ class MarathonEndpoint(RecordingTcpIpEndpoint):
            the cluster
         """
         with self._context.lock:
-            self._context.data["endpoint-content"]["apps"].append(NGINX_TASK)
+            self._context.data["endpoint-content"]["apps"].append(NGINX_TASK_ENABLED)
 
     def remove_leader(self, *_):
         """Change the endpoint output so that it simulates absence of the Marathon

--- a/test-harness/modules/mocker/endpoints/marathon.py
+++ b/test-harness/modules/mocker/endpoints/marathon.py
@@ -168,6 +168,7 @@ NGINX_TASK_ALWAYSTHERE = {
         }
     ]
 }
+
 NGINX_TASK_ENABLED = {
     "id": "/nginx-enabled",
     "cmd": ("cd /opt/bitnami/nginx && harpoon initialize nginx && "
@@ -382,8 +383,8 @@ class MarathonEndpoint(RecordingTcpIpEndpoint):
             self._context.data["leader-content"] = {"leader": "127.0.0.2:80"}
 
     def enable_nginx_task(self, *_):
-        """Change the endpoint output so that it simulates Nginx task running in
-           the cluster
+        """Change the endpoint output so that it simulates extra Nginx task
+           running in the cluster
         """
         with self._context.lock:
             self._context.data["endpoint-content"]["apps"].append(NGINX_TASK_ENABLED)

--- a/test-harness/tests/open/test_master.py
+++ b/test-harness/tests/open/test_master.py
@@ -15,6 +15,7 @@ from generic_test_code import (
 log = logging.getLogger(__name__)
 
 authed_endpoints = ['/exhibitor',
+                    '/service/nginx-alwaysthere',
                     '/system/health/v1',
                     '/system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/logs/v1'
                     '/system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0'

--- a/test-harness/tests/test_cache.py
+++ b/test-harness/tests/test_cache.py
@@ -404,7 +404,7 @@ class TestCache():
             resp = requests.get(url,
                                 allow_redirects=False,
                                 headers=superuser_user_header)
-            assert resp.status_code == 404
+            assert resp.status_code == 500
 
             mocker.send_command(endpoint_id='http://127.0.0.1:8080',
                                 func_name='enable_nginx_task')

--- a/test-harness/tests/test_cache.py
+++ b/test-harness/tests/test_cache.py
@@ -162,7 +162,7 @@ class TestCache():
 
         mocker.send_command(endpoint_id='http://127.0.0.1:8080',
                             func_name='enable_nginx_task')
-        url = ar.make_url_from_path('/service/nginx/foo/bar/')
+        url = ar.make_url_from_path('/service/nginx-enabled/foo/bar/')
 
         with GuardedSubprocess(ar):
             # Register Line buffer filter:
@@ -215,7 +215,7 @@ class TestCache():
 
         mocker.send_command(endpoint_id='http://127.0.0.1:8080',
                             func_name='enable_nginx_task')
-        url = ar.make_url_from_path('/service/nginx/foo/bar/')
+        url = ar.make_url_from_path('/service/nginx-enabled/foo/bar/')
 
         with GuardedSubprocess(ar):
             # Register Line buffer filter:
@@ -376,7 +376,7 @@ class TestCache():
                             func_name='enable_nginx_task')
 
         ar = nginx_class()
-        url = ar.make_url_from_path('/service/nginx/bar/baz')
+        url = ar.make_url_from_path('/service/nginx-enabled/bar/baz')
 
         with GuardedSubprocess(ar):
             lbf = LineBufferFilter(filter_regexp,
@@ -398,7 +398,7 @@ class TestCache():
             self, nginx_class, superuser_user_header, mocker):
         cache_poll_period = 4
         ar = nginx_class(cache_poll_period=cache_poll_period, cache_expiration=3)
-        url = ar.make_url_from_path('/service/nginx/bar/baz')
+        url = ar.make_url_from_path('/service/nginx-enabled/bar/baz')
 
         with GuardedSubprocess(ar):
             resp = requests.get(url,
@@ -524,7 +524,7 @@ class TestCache():
                             func_name='record_requests')
 
         ar = nginx_class()
-        url = ar.make_url_from_path('/service/nginx/bar/baz')
+        url = ar.make_url_from_path('/service/nginx-enabled/bar/baz')
 
         with GuardedSubprocess(ar):
             # Let the cache warm-up:


### PR DESCRIPTION
This PR:
* reverts new `/service` behaviour, fixing oracle behaviour is tracked in DCOS-14008
* refactors Marathon endpoint mock for greater flexibility. Instead of one dynamic task, user gets one "always there" task and one that needs to be enabled first (old behaviour).

PR for Open: https://github.com/dcos/dcos/pull/1228