### PR TITLE
Adjust build scripts in order to extract openresty compile stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,22 @@
 FROM ubuntu:16.04
-MAINTAINER prozlach@mesosphere.io
 
-ENV OPENRESTY_VERSION 1.9.15.1
-ENV OPENRESTY_DOWNLOAD_URL https://openresty.org/download/openresty-$OPENRESTY_VERSION.tar.gz
-ENV OPENRESTY_DOWNLOAD_SHASUM 491a84d70ed10b79abb9d1a7496ee57a9244350b
+# Let's try to limit the number of layers to minimum:
+ENV OPENRESTY_VERSION=1.9.15.1 \
+    OPENRESTY_DOWNLOAD_SHASUM=491a84d70ed10b79abb9d1a7496ee57a9244350b \
+    OPENRESTY_DIR=/usr/local/src/openresty \
+    OPENRESTY_COMPILE_SCRIPT=/usr/local/src/build-resty.sh \
+    OPENRESTY_COMPILE_OPTS="" \
+    VENV_DIR=/usr/local/venv \
+    AR_BIN_DIR=/usr/local/adminrouter/ \
+    VEGETA_DOWNLOAD_SHA256=2f0a69d0ae6f0bf268b7f655bd37c0104d5568d5b2bc45bbb2c405266f74e33d \
+    VEGETA_DOWNLOAD_URL=https://github.com/tsenart/vegeta/releases/download/v6.1.1/vegeta-v6.1.1-linux-amd64.tar.gz \
+    IAM_PUBKEY_FILE_PATH=/usr/local/iam.jwt-key.pub \
+    IAM_PRIVKEY_FILE_PATH=/usr/local/iam.jwt-key.priv \
+    IAM_SHARED_SECRET_FILE_PATH=/usr/local/iam.jwt-key.shared-secret
 
-ENV VENV_DIR /usr/local/venv
-ENV AR_CONF_DIR /usr/local/src/adminrouter
-ENV OPENRESTY_DIR /usr/local/src/openresty
-ENV AR_BIN_DIR /usr/local/adminrouter
+# These depend on other ENV vars, so we need a separate ENV block:
+ENV OPENRESTY_DOWNLOAD_URL=https://openresty.org/download/openresty-$OPENRESTY_VERSION.tar.gz \
+    AUTH_ERROR_PAGE_DIR_PATH=${AR_BIN_DIR}/nginx/conf/errorpages
 
 WORKDIR /usr/local/src/
 
@@ -51,7 +59,8 @@ RUN set -ex \
         python3 \
         python3-dev \
         python3-pip \
-        python3-virtualenv
+        python3-virtualenv \
+        gettext-base
 
 # Upgrading pip/setuptools and making the upgrade actually apply in the
 # following filesystem layers works more reliable when using a virtualenv for
@@ -70,62 +79,40 @@ COPY ./requirements-tests.txt .
 RUN pip install -r requirements-tests.txt
 
 # Download Vegeta tool for benchmarking
-ENV VEGETA_DOWNLOAD_SHA256 2f0a69d0ae6f0bf268b7f655bd37c0104d5568d5b2bc45bbb2c405266f74e33d
-ENV VEGETA_DOWNLOAD_URL https://github.com/tsenart/vegeta/releases/download/v6.1.1/vegeta-v6.1.1-linux-amd64.tar.gz
-
 RUN curl -fsSL "$VEGETA_DOWNLOAD_URL" -o vegeta.tar.gz \
     && echo "$VEGETA_DOWNLOAD_SHA256  vegeta.tar.gz" | sha256sum -c - \
         && tar -C /usr/local/bin -xzf vegeta.tar.gz \
         && rm vegeta.tar.gz
 
-# Compile AR, prepare it for running
-# This mimics the settings from dcos-image except for '--with-debug'
+# Prepare Openresty. Compilation is done in Makefile itself so that
+# this container can be reused during DC/OS build.
 RUN set -ex \
     && curl -fsSL "$OPENRESTY_DOWNLOAD_URL" -o openresty.tar.gz \
     && echo "$OPENRESTY_DOWNLOAD_SHASUM  openresty.tar.gz" | shasum -c - \
     && mkdir -pv $OPENRESTY_DIR \
     && tar --strip-components=1 -C $OPENRESTY_DIR -xzf openresty.tar.gz \
-    && rm openresty.tar.gz \
-    && cd $OPENRESTY_DIR \
-    && ./configure \
-        "--prefix=$AR_BIN_DIR" \
-        --with-ipv6 \
-        --with-debug \
-        --with-file-aio \
-        --with-http_gunzip_module \
-        --with-http_gzip_static_module \
-        --without-mail_pop3_module \
-        --without-mail_imap_module \
-        --without-mail_smtp_module \
-        --with-http_ssl_module \
-        --with-luajit \
-    && make \
-    && make install \
-    && mv -v ${AR_BIN_DIR}/nginx/conf/ ${AR_BIN_DIR}/nginx/conf.orig/ \
-    && ln -s ${AR_CONF_DIR} ${AR_BIN_DIR}/nginx/conf
+    && rm openresty.tar.gz
 
-# Some AR variables that mimic DC/OS:
-COPY ./iam.jwt-key.pub /usr/local/
-COPY ./iam.jwt-key.priv /usr/local/
-COPY ./iam.jwt-key.shared-secret /usr/local/
-ENV IAM_PUBKEY_FILE_PATH=/usr/local/iam.jwt-key.pub
-ENV IAM_PRIVKEY_FILE_PATH=/usr/local/iam.jwt-key.priv
-ENV IAM_SHARED_SECRET_FILE_PATH=/usr/local/iam.jwt-key.shared-secret
-ENV AUTH_ERROR_PAGE_DIR_PATH=${AR_BIN_DIR}/nginx/conf/errorpages
+COPY build-resty.sh $OPENRESTY_COMPILE_SCRIPT
 
-# Some files that mimic DC/OS:
-COPY ./ca.crt /run/dcos/pki/CA/certs/ca.crt
-COPY ./adminrouter.crt /run/dcos/pki/tls/certs/adminrouter.crt
-COPY ./adminrouter.key /run/dcos/pki/tls/private/adminrouter.key
-COPY ./adminrouter-redirect-http-https.conf /opt/mesosphere/etc/adminrouter-redirect-http-https.conf
-COPY ./adminrouter-upstreams.conf /opt/mesosphere/etc/adminrouter-upstreams.conf
+# Some files that mimic DC/OS environment:
+COPY iam.jwt-key.pub \
+     iam.jwt-key.priv \
+     iam.jwt-key.shared-secret \
+        /usr/local/
+# The contents of adminrouter-listen* files differ from the ones that are
+# shipped with DC/OS - the IP addresses Nginx binds to are limited to only
+# 127.0.0.1 instead of *. The reason for it is that some endpoints also need to
+# listen on TCP port 80 and this causes conflicts.
+COPY adminrouter-redirect-http-https.conf \
+     adminrouter-upstreams.conf \
+     adminrouter-listen-master.conf \
+     adminrouter-listen-agent.conf \
+        /opt/mesosphere/etc/
+COPY ca.crt /run/dcos/pki/CA/certs/
+COPY adminrouter.crt /run/dcos/pki/tls/certs/
+COPY adminrouter.key /run/dcos/pki/tls/private/
 
-# The contents of this file differ from the one that is shipped with DC/OS:
-# the IP addresses Nginx binds to are limited to only 127.0.0.1 instead of *.
-# The reason for it is that some endpoints need to listen on TCP port 80 due
-# to the way Nginx is configured.
-COPY ./adminrouter-listen-master.conf /opt/mesosphere/etc/adminrouter-listen-master.conf
-COPY ./adminrouter-listen-agent.conf /opt/mesosphere/etc/adminrouter-listen-agent.conf
 
 # dnsmasq stuff:
 COPY ./dnsmasq.conf /etc/dnsmasq.conf
@@ -136,6 +123,6 @@ RUN echo "nameserver 127.0.0.1" > /etc/resolv.conf
 RUN echo "nameserver 8.8.8.8\nnameserver 8.8.4.4\n" > /etc/resolv.conf.dnsmasq
 COPY ./hosts.dnsmasq /etc/hosts.dnsmasq
 
-WORKDIR $AR_CONF_DIR
+WORKDIR $AR_BIN_DIR/nginx/conf/
 
 CMD ["/bin/bash"]

--- a/docker/build-resty.sh
+++ b/docker/build-resty.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e  # Fail the script if anything fails
+set -x  # Verbose output
+set -u  # Undefined variables
+
+cd $OPENRESTY_DIR
+./configure \
+    "--prefix=$AR_BIN_DIR" \
+    --with-ipv6 \
+    --with-file-aio \
+    --with-http_gunzip_module \
+    --with-http_gzip_static_module \
+    --without-mail_pop3_module \
+    --without-mail_imap_module \
+    --without-mail_smtp_module \
+    --with-http_ssl_module \
+    --with-luajit \
+    "$@"
+
+make -j${NUM_CORES}
+make install


### PR DESCRIPTION
Relevant issues:
* https://jira.mesosphere.com/browse/DCOS-11919?filter=-1

This PR:
* adjusts AR build scripts so that it's possible to use them in DC/OS build environment, Jenkins tests build and developers laptop. This basically means extracting OpenResty compilation stage into a separate script.
* small bugfixes and optimisations